### PR TITLE
pbench-result-data-sample doc type migration (phase one)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ export default {
       "results": "http://results.example.com",
       "graphql": "http://graphql.example.com",
       "prefix": "example.prefix",
-      "run_index": "example.index"
+      "run_index": "example.index",
+      "result_index": "example.index"
   },
 }
 ```

--- a/mock/api.js
+++ b/mock/api.js
@@ -110,3 +110,236 @@ export const mockStore = {
   search: {},
   store: {},
 };
+
+export const mockDataSample = [
+  {
+    hits: {
+      hits: [
+        {
+          _source: {
+            run: {
+              id: 'test_run_id',
+              controller: 'test_controller',
+              name: 'test_run_name',
+              script: 'test_script',
+              config: 'test_config',
+            },
+            iteration: { name: 'test_iteration_1', number: 1 },
+            benchmark: {
+              instances: 1,
+              max_stddevpct: 1,
+              message_size_bytes: 1,
+              primary_metric: 'test_measurement_title',
+              test_type: 'stream',
+            },
+            sample: {
+              closest_sample: 1,
+              mean: 0.1,
+              stddev: 0.1,
+              stddevpct: 1,
+              uid: 'test_measurement_id',
+              measurement_type: 'test_measurement_type',
+              measurement_idx: 0,
+              measurement_title: 'test_measurement_title',
+              '@idx': 0,
+              name: 'sample1',
+            },
+          },
+        },
+      ],
+    },
+    aggregations: {
+      id: {
+        buckets: [
+          {
+            key: 'test_run_name',
+            type: {
+              buckets: [
+                {
+                  key: 'test_measurement_type',
+                  title: {
+                    buckets: [
+                      {
+                        key: 'test_measurement_title',
+                        uid: {
+                          buckets: [
+                            {
+                              key: 'test_measurement_id',
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      name: {
+        buckets: [
+          {
+            key: 'test_run_name',
+          },
+        ],
+      },
+      controller: {
+        buckets: [
+          {
+            key: 'test_controller',
+          },
+        ],
+      },
+    },
+  },
+];
+
+export const expectedSampleData = {
+  runs: {
+    test_run_name: {
+      columns: [
+        { title: 'Iteration Name', dataIndex: 'name', key: 'name' },
+        {
+          title: 'test_measurement_type',
+          children: [
+            {
+              title: 'test_measurement_title',
+              children: [
+                {
+                  title: 'test_measurement_type-test_measurement_title-test_measurement_id',
+                  children: [
+                    {
+                      title: 'mean',
+                      dataIndex:
+                        'test_measurement_type-test_measurement_title-test_measurement_id-mean',
+                      key: 'test_measurement_type-test_measurement_title-test_measurement_id-mean',
+                    },
+                    {
+                      title: 'stddevpct',
+                      dataIndex:
+                        'test_measurement_type-test_measurement_title-test_measurement_id-stddevpct',
+                      key:
+                        'test_measurement_type-test_measurement_title-test_measurement_id-stddevpct',
+                    },
+                    {
+                      title: 'closest_sample',
+                      dataIndex:
+                        'test_measurement_type-test_measurement_title-test_measurement_id-closest_sample',
+                      key:
+                        'test_measurement_type-test_measurement_title-test_measurement_id-closest_sample',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      run_name: 'test_run_name',
+      run_controller: 'test_controller',
+      iterations: {
+        test_iteration_1: {
+          name: 'test_iteration_1',
+          number: 1,
+          closest_sample: 1,
+          'test_measurement_type-test_measurement_title-test_measurement_id-closest_sample': 1,
+          'test_measurement_type-test_measurement_title-test_measurement_id-mean': 0.1,
+          'test_measurement_type-test_measurement_title-test_measurement_id-stddevpct': 1,
+          samples: {
+            'test_measurement_title-sample1': {
+              sample: {
+                closest_sample: 1,
+                mean: 0.1,
+                stddev: 0.1,
+                stddevpct: 1,
+                uid: 'test_measurement_id',
+                measurement_type: 'test_measurement_type',
+                measurement_idx: 0,
+                measurement_title: 'test_measurement_title',
+                '@idx': 0,
+                name: 'sample1',
+              },
+              benchmark: {
+                instances: 1,
+                max_stddevpct: 1,
+                message_size_bytes: 1,
+                primary_metric: 'test_measurement_title',
+                test_type: 'stream',
+              },
+              run: {
+                id: 'test_run_id',
+                controller: 'test_controller',
+                name: 'test_run_name',
+                script: 'test_script',
+                config: 'test_config',
+              },
+            },
+          },
+        },
+      },
+      id: 'test_run_name',
+      primaryMetrics: {},
+    },
+  },
+  iterationParams: {
+    instances: [1],
+    message_size_bytes: [1],
+    primary_metric: ['test_measurement_title'],
+    test_type: ['stream'],
+    closest_sample: [1],
+    uid: ['test_measurement_id'],
+    measurement_type: ['test_measurement_type'],
+    measurement_title: ['test_measurement_title'],
+  },
+};
+
+export const expectedClusterData = {
+  data: {
+    test_measurement_title: [
+      {
+        instances: 1,
+        max_stddevpct: 1,
+        message_size_bytes: 1,
+        primary_metric: 'test_measurement_title',
+        test_type: 'stream',
+        cluster: {
+          test_run_name: 0.1,
+          name_test_run_name: 'sample1',
+          percent_test_run_name: 1,
+          cluster: 1,
+        },
+        test_run_name: {
+          sample: {
+            closest_sample: 1,
+            mean: 0.1,
+            stddev: 0.1,
+            stddevpct: 1,
+            uid: 'test_measurement_id',
+            measurement_type: 'test_measurement_type',
+            measurement_idx: 0,
+            measurement_title: 'test_measurement_title',
+            '@idx': 0,
+            name: 'sample1',
+          },
+          run: {
+            id: 'test_run_id',
+            controller: 'test_controller',
+            name: 'test_run_name',
+            script: 'test_script',
+            config: 'test_config',
+          },
+          benchmark: {
+            instances: 1,
+            max_stddevpct: 1,
+            message_size_bytes: 1,
+            primary_metric: 'test_measurement_title',
+            test_type: 'stream',
+          },
+        },
+      },
+    ],
+  },
+  keys: {},
+  params: {},
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint --fix --ext .js src && npm run lint:style",
     "lint-staged": "lint-staged",
     "lint-staged:js": "eslint --ext .js src mock",
-    "test": "umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand --updateSnapshot",
+    "test": "umi test ./src/components ./src/pages ./src/utils --verbose --maxWorkers=1 --runInBand --updateSnapshot",
     "test:component": "umi test @",
     "test:e2e": "umi test ./src/e2e --verbose",
     "test:all": "node ./tests/run-tests.js",

--- a/src/components/TableFilterSelection/index.js
+++ b/src/components/TableFilterSelection/index.js
@@ -17,34 +17,15 @@ export default class TableFilterSelection extends Component {
 
     this.state = {
       selectedFilters: {},
-      selectedPorts: [],
       updateFiltersDisabled: true,
     };
   }
 
-  componentDidUpdate = prevProps => {
-    const { ports } = this.props;
-
-    if (ports !== prevProps.ports) {
-      this.filterDefaultPort();
-    }
-  };
-
-  filterDefaultPort = () => {
-    const { ports } = this.props;
-
-    Promise.resolve(this.onPortChange([ports[ports.findIndex(port => port.includes('all'))]])).then(
-      () => {
-        this.onFilterTable();
-      }
-    );
-  };
-
   onFilterTable = () => {
-    const { selectedFilters, selectedPorts } = this.state;
+    const { selectedFilters } = this.state;
     const { onFilterTable } = this.props;
 
-    onFilterTable(selectedFilters, selectedPorts);
+    onFilterTable(selectedFilters);
     this.setState({ updateFiltersDisabled: true });
   };
 
@@ -61,26 +42,16 @@ export default class TableFilterSelection extends Component {
     this.setState({ updateFiltersDisabled: false });
   };
 
-  onPortChange = value => {
-    this.setState({ selectedPorts: value });
+  onClearFilters = () => {
+    this.setState({
+      selectedFilters: [],
+    });
     this.setState({ updateFiltersDisabled: false });
   };
 
-  onClearFilters = () => {
-    this.setState(
-      {
-        selectedFilters: [],
-        selectedPorts: [],
-      },
-      () => {
-        this.filterDefaultPort();
-      }
-    );
-  };
-
   render() {
-    const { filters, ports } = this.props;
-    const { selectedFilters, selectedPorts, updateFiltersDisabled } = this.state;
+    const { filters } = this.props;
+    const { selectedFilters, updateFiltersDisabled } = this.state;
 
     return (
       <div>
@@ -113,27 +84,6 @@ export default class TableFilterSelection extends Component {
                 </Select>
               </div>
             ))}
-          </Row>
-          <Row style={{ display: 'flex', flexWrap: 'wrap' }}>
-            <div>
-              <p style={{ marginBottom: 4, fontSize: 12, fontWeight: 600 }}>hostname & port</p>
-              <Select
-                key="port"
-                mode="multiple"
-                allowClear
-                placeholder="port"
-                style={{ marginRight: 16, marginBottom: 16, width: 320 }}
-                dropdownMatchSelectWidth={false}
-                value={selectedPorts}
-                onChange={this.onPortChange}
-              >
-                {ports.map(port => (
-                  <Option key={port} value={port}>
-                    {port}
-                  </Option>
-                ))}
-              </Select>
-            </div>
           </Row>
           <Row>
             <div style={{ textAlign: 'right' }}>

--- a/src/components/TableFilterSelection/index.test.js
+++ b/src/components/TableFilterSelection/index.test.js
@@ -15,7 +15,6 @@ const mockProps = {
     protocol: ['tcp'],
     test_type: ['stream', 'maerts', 'bidirec', 'rr'],
   },
-  ports: ['client_hostname:1', 'client_hostname:2', 'client_hostname:all'],
 };
 
 const mockDispatch = jest.fn();
@@ -29,9 +28,9 @@ describe('test rendering of TableFilterSelection page component', () => {
     expect(wrapper).toMatchSnapshot();
   });
   it('check rendering', () => {
-    expect(wrapper.find('Select').length).toEqual(8);
+    expect(wrapper.find('Select').length).toEqual(7);
     expect(wrapper.find('Form')).toHaveLength(1);
-    expect(wrapper.find('Row')).toHaveLength(3);
+    expect(wrapper.find('Row')).toHaveLength(2);
     expect(wrapper.find('Button')).toHaveLength(2);
   });
 });
@@ -73,21 +72,5 @@ describe('test interaction of TableFilterSelection page component', () => {
       .at(1)
       .simulate('change');
     expect(wrapper.state('selectedFilters')).toEqual(state);
-  });
-  it('Check change of Port', () => {
-    wrapper
-      .find('Select')
-      .last()
-      .simulate('change', 'client_hostname:3');
-    expect(wrapper.state('selectedPorts')).toEqual('client_hostname:3');
-  });
-});
-
-describe('test life cycle method update', () => {
-  it('should call filterDefaultPort when componentDidUpdate method is invoked', () => {
-    const spy = jest.spyOn(wrapper.instance(), 'filterDefaultPort');
-    wrapper.instance().forceUpdate();
-    wrapper.setProps({ ports: ['client_hostname:3'] });
-    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/RunComparison/index.test.js
+++ b/src/pages/RunComparison/index.test.js
@@ -4,7 +4,6 @@ import Adapter from 'enzyme-adapter-react-16';
 import 'jest-canvas-mock';
 
 import RunComparison from './index';
-import { parseClusteredIterations } from '../../utils/parse';
 
 const mockProps = {
   selectedControllers: ['controller1', 'controller2'],
@@ -29,7 +28,6 @@ clusteredIterations.sample_metric = [
 ];
 const clusterLabels = [];
 clusterLabels.sample_metric = ['sample-1'];
-const selectedConfig = ['benchmark-sample-1'];
 
 const mockDispatch = jest.fn();
 configure({ adapter: new Adapter() });
@@ -45,10 +43,5 @@ describe('test RunComparison page component', () => {
 
   it('render multiple user selected controllers', () => {
     expect(wrapper.instance().props.selectedControllers).toEqual(['controller1', 'controller2']);
-  });
-
-  it('displays correct metric data', () => {
-    const result = parseClusteredIterations(clusteredIterations, clusterLabels, selectedConfig);
-    expect(result.tableData.sample_metric[0].primaryMetric).toEqual('sample_metric');
   });
 });

--- a/src/pages/Summary/index.js
+++ b/src/pages/Summary/index.js
@@ -49,7 +49,6 @@ const tocColumns = [
 @connect(({ global, datastore, dashboard, loading }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
-  iterationPorts: dashboard.iterationPorts,
   result: dashboard.result,
   tocResult: dashboard.tocResult,
   datastoreConfig: datastore.datastoreConfig,
@@ -57,7 +56,7 @@ const tocColumns = [
   selectedResults: global.selectedResults,
   selectedIndices: global.selectedIndices,
   loadingSummary:
-    loading.effects['dashboard/fetchIterations'] ||
+    loading.effects['dashboard/fetchIterationSamples'] ||
     loading.effects['dashboard/fetchResult'] ||
     loading.effects['dashboard/fetchTocResult'],
 }))
@@ -68,7 +67,7 @@ class Summary extends React.Component {
 
     this.state = {
       activeSummaryTab: 'iterations',
-      resultIterations: iterations[0],
+      resultIterations: iterations,
     };
   }
 
@@ -76,8 +75,8 @@ class Summary extends React.Component {
     const { dispatch, datastoreConfig, selectedIndices, selectedResults } = this.props;
 
     dispatch({
-      type: 'dashboard/fetchIterations',
-      payload: { selectedResults, datastoreConfig },
+      type: 'dashboard/fetchIterationSamples',
+      payload: { selectedResults, selectedIndices, datastoreConfig },
     });
     dispatch({
       type: 'dashboard/fetchResult',
@@ -101,7 +100,7 @@ class Summary extends React.Component {
     const { iterations } = this.props;
 
     if (nextProps.iterations !== iterations) {
-      this.setState({ resultIterations: nextProps.iterations[0] });
+      this.setState({ resultIterations: nextProps.iterations });
     }
   }
 
@@ -109,7 +108,7 @@ class Summary extends React.Component {
     const { iterations } = this.props;
 
     const filteredIterations = filterIterations(iterations, selectedParams, selectedPorts);
-    this.setState({ resultIterations: filteredIterations[0] });
+    this.setState({ resultIterations: filteredIterations });
   };
 
   onTabChange = key => {
@@ -122,7 +121,6 @@ class Summary extends React.Component {
       selectedResults,
       loadingSummary,
       iterationParams,
-      iterationPorts,
       selectedControllers,
       tocResult,
       result,
@@ -132,15 +130,17 @@ class Summary extends React.Component {
       iterations: (
         <Card title="Result Iterations" style={{ marginTop: 32 }}>
           <Spin spinning={loadingSummary} tip="Loading Iterations...">
-            <TableFilterSelection
-              onFilterTable={this.onFilterTable}
-              filters={iterationParams}
-              ports={iterationPorts}
-            />
+            <TableFilterSelection onFilterTable={this.onFilterTable} filters={iterationParams} />
             <Table
               style={{ marginTop: 16 }}
-              columns={resultIterations ? resultIterations.columns : []}
-              dataSource={resultIterations ? resultIterations.iterations : []}
+              columns={
+                resultIterations[Object.keys(resultIterations)[0]] &&
+                resultIterations[Object.keys(resultIterations)[0]].columns
+              }
+              dataSource={
+                resultIterations[Object.keys(resultIterations)[0]] &&
+                Object.values(resultIterations[Object.keys(resultIterations)[0]].iterations)
+              }
               bordered
             />
           </Spin>

--- a/src/pages/Summary/index.test.js
+++ b/src/pages/Summary/index.test.js
@@ -11,7 +11,11 @@ const mockProps = {
   },
   selectedResults: ['test_result'],
   selectedControllers: ['test_controller'],
-  iterations: [{}],
+  iterations: {
+    test_result: {
+      iterations: {},
+    },
+  },
   iterationParams: {},
 };
 

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -1,12 +1,14 @@
-import _ from 'lodash';
 import request from '../utils/request';
-import { renameProp } from '../utils/utils';
 
-function parseMonths(datastoreConfig, selectedIndices) {
+function parseMonths(datastoreConfig, index, selectedIndices) {
   let indices = '';
 
   selectedIndices.forEach(value => {
-    indices += `${datastoreConfig.prefix + datastoreConfig.run_index + value},`;
+    if (index === datastoreConfig.result_index) {
+      indices += `${datastoreConfig.prefix + index + value}-*,`;
+    } else {
+      indices += `${datastoreConfig.prefix + index + value},`;
+    }
   });
 
   return indices;
@@ -17,6 +19,7 @@ export async function queryControllers(params) {
 
   const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
     datastoreConfig,
+    datastoreConfig.run_index,
     selectedIndices
   )}/_search`;
 
@@ -52,6 +55,7 @@ export async function queryResults(params) {
 
   const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
     datastoreConfig,
+    datastoreConfig.run_index,
     selectedIndices
   )}/_search`;
 
@@ -91,6 +95,7 @@ export async function queryResult(params) {
 
   const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
     datastoreConfig,
+    datastoreConfig.run_index,
     selectedIndices
   )}/_search?source=`;
 
@@ -111,10 +116,145 @@ export async function queryTocResult(params) {
 
   const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
     datastoreConfig,
+    datastoreConfig.run_index,
     selectedIndices
   )}/_search?q=_parent:"${id}"`;
 
   return request.post(endpoint);
+}
+
+export async function queryIterationSamples(params) {
+  const { datastoreConfig, selectedIndices, selectedResults } = params;
+
+  const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
+    datastoreConfig,
+    datastoreConfig.result_index,
+    selectedIndices
+  )}/_search?scroll=1m`;
+
+  const iterationSampleRequests = [];
+  selectedResults.forEach(run => {
+    iterationSampleRequests.push(
+      request.post(endpoint, {
+        data: {
+          query: {
+            filtered: {
+              query: {
+                multi_match: {
+                  query: run.id,
+                  fields: ['run.id'],
+                },
+              },
+              filter: {
+                term: {
+                  _type: 'pbench-result-data-sample',
+                },
+              },
+            },
+          },
+          aggs: {
+            id: {
+              terms: {
+                field: 'run.id',
+              },
+              aggs: {
+                type: {
+                  terms: {
+                    field: 'sample.measurement_type',
+                  },
+                  aggs: {
+                    title: {
+                      terms: {
+                        field: 'sample.measurement_title',
+                      },
+                      aggs: {
+                        uid: {
+                          terms: {
+                            field: 'sample.uid',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            name: {
+              terms: {
+                field: 'run.name',
+              },
+            },
+            controller: {
+              terms: {
+                field: 'run.controller',
+              },
+            },
+          },
+          size: 10000,
+          sort: [
+            {
+              'iteration.number': {
+                order: 'asc',
+                unmapped_type: 'boolean',
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  return Promise.all(iterationSampleRequests).then(iterations => {
+    return iterations;
+  });
+}
+
+export async function queryTimeseriesData(params) {
+  const { datastoreConfig, selectedIndices, selectedResults } = params;
+
+  const endpoint = `${datastoreConfig.elasticsearch}/${parseMonths(
+    datastoreConfig,
+    datastoreConfig.result_index,
+    selectedIndices
+  )}/_search?scroll=1m`;
+
+  const iterationSampleRequests = [];
+  selectedResults.forEach(run => {
+    iterationSampleRequests.push(
+      request.post(endpoint, {
+        data: {
+          query: {
+            filtered: {
+              query: {
+                multi_match: {
+                  query: run.id,
+                  fields: ['run.id'],
+                },
+              },
+              filter: {
+                term: {
+                  _type: 'pbench-result-data',
+                },
+              },
+            },
+          },
+          size: 10000,
+          sort: [
+            {
+              '@timestamp_original': {
+                order: 'asc',
+                unmapped_type: 'boolean',
+              },
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  return Promise.all(iterationSampleRequests).then(iterations => {
+    return iterations;
+  });
 }
 
 export async function queryIterations(params) {
@@ -150,112 +290,5 @@ export async function queryIterations(params) {
       });
     });
     return iterations;
-  });
-}
-
-export async function queryTimeseriesData(params) {
-  const { datastoreConfig, clusteredIterations } = params;
-  const iterationRequests = [];
-
-  Object.keys(clusteredIterations).forEach(primaryMetric => {
-    Object.keys(clusteredIterations[primaryMetric]).forEach(cluster => {
-      Object.keys(clusteredIterations[primaryMetric][cluster]).forEach(iteration => {
-        const iterationMetadata = clusteredIterations[primaryMetric][cluster][iteration];
-        if (iterationMetadata.iteration_name_format !== undefined) {
-          iterationMetadata.iteration_name_format = iterationMetadata.iteration_name_format.replace(
-            '%d',
-            iterationMetadata.iteration_number
-          );
-          iterationMetadata.iteration_name_format = iterationMetadata.iteration_name_format.replace(
-            '%s',
-            iterationMetadata.iteration_name
-          );
-          iterationMetadata.name = iterationMetadata.iteration_name_format;
-        } else {
-          iterationMetadata.name = `${iterationMetadata.iteration_number}-${
-            iterationMetadata.iteration_name
-          }`;
-        }
-        iterationRequests.push(
-          request.get(
-            `${datastoreConfig.results}/incoming/${encodeURI(
-              iterationMetadata.controller_name
-            )}/${encodeURI(iterationMetadata.result_name)}/${encodeURI(
-              iterationMetadata.name
-            )}/sample${encodeURI(iterationMetadata.closest_sample)}/result.json`
-          )
-        );
-      });
-    });
-  });
-
-  return Promise.all(iterationRequests).then(args => {
-    const timeseriesData = [];
-    const timeseriesDropdown = [];
-    const timeseriesDropdownSelected = [];
-    let responseCount = 0;
-
-    Object.keys(clusteredIterations).forEach(primaryMetric => {
-      timeseriesData[primaryMetric] = [];
-      Object.keys(clusteredIterations[primaryMetric]).forEach(cluster => {
-        timeseriesData[primaryMetric][cluster] = [];
-        let iterationTimeseriesData = [];
-        const timeseriesLabels = ['time'];
-        Object.keys(clusteredIterations[primaryMetric][cluster]).forEach(iteration => {
-          const iterationTypes = Object.keys(args[responseCount]);
-          Object.keys(iterationTypes).forEach(iterationTest => {
-            if (
-              Object.keys(args[responseCount][iterationTypes[iterationTest]]).includes(
-                primaryMetric
-              )
-            ) {
-              const hosts = args[responseCount][iterationTypes[iterationTest]][primaryMetric];
-              Object.keys(hosts).forEach(host => {
-                if (hosts[host].client_hostname === 'all') {
-                  Object.keys(hosts[host].timeseries).forEach(item => {
-                    hosts[host].timeseries[item] = renameProp(
-                      'date',
-                      'x',
-                      hosts[host].timeseries[item]
-                    );
-                    hosts[host].timeseries[item] = renameProp(
-                      'value',
-                      `y${parseInt(iteration, 10) + 1}`,
-                      hosts[host].timeseries[item]
-                    );
-                  });
-                  timeseriesLabels.push(
-                    `${clusteredIterations[primaryMetric][cluster][iteration].result_name}-${
-                      clusteredIterations[primaryMetric][cluster][iteration].iteration_name
-                    }`
-                  );
-                  iterationTimeseriesData = _.merge(
-                    iterationTimeseriesData,
-                    hosts[host].timeseries
-                  );
-                  responseCount += 1;
-                }
-              });
-            }
-          });
-        });
-        const timeLabel = timeseriesLabels.splice(0, 1)[0];
-        timeseriesLabels.splice(1, 0, timeLabel);
-        timeseriesData[primaryMetric][cluster].push({
-          data_series_names: timeseriesLabels,
-          data: iterationTimeseriesData.map(Object.values),
-          x_axis_series: 'time',
-        });
-      });
-    });
-    Object.keys(timeseriesData).forEach(primaryMetric => {
-      timeseriesDropdownSelected[primaryMetric] = 0;
-      timeseriesDropdown[primaryMetric] = Object.keys(timeseriesData[primaryMetric]);
-    });
-    return {
-      timeseriesData,
-      timeseriesDropdownSelected,
-      timeseriesDropdown,
-    };
   });
 }

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,505 +1,201 @@
-/* eslint-disable no-param-reassign */
 import _ from 'lodash';
-import { Icon } from 'antd';
-import React from 'react';
 
-export const parseIterationData = results => {
-  const iterations = [];
-  const iterationParams = {};
-  const iterationPorts = [];
-  const selectedIterationKeys = [];
+export const filterIterations = (results, selectedParams) => {
+  const resultsCopy = _.cloneDeep(results);
 
-  results.forEach(result => {
-    const columns = [
-      {
-        title: 'Iteration Name',
-        dataIndex: 'iteration_name',
-        width: 150,
-        key: 'iteration_name',
-      },
-    ];
-    const parsedResponse = {
-      iterations: [],
-      columns: [],
-      resultName: '',
-    };
-    selectedIterationKeys.push([]);
-
-    result.iterationData.forEach(iteration => {
-      let iterationMetadata = {
-        iteration_name: iteration.iteration_name,
-        iteration_name_format: iteration.iteration_name_format,
-        iteration_number: iteration.iteration_number,
-        result_name: result.resultName,
-        controller_name: result.controllerName,
-        table: result.tableId,
-        key: iteration.iteration_number,
-      };
-      const iterationConfig = iteration.iteration_data.parameters.benchmark
-        ? Object.entries(iteration.iteration_data.parameters.benchmark[0])
-        : [];
-      const blacklistedParams = ['uid', 'clients', 'servers', 'max_stddevpct'];
-      iterationConfig.forEach(([parameter, value]) => {
-        if (!blacklistedParams.includes(parameter)) {
-          if (iterationParams[parameter]) {
-            if (!iterationParams[parameter].includes(value)) {
-              iterationParams[parameter].push(value);
-            }
-          } else {
-            iterationParams[parameter] = [value];
-          }
+  Object.entries(resultsCopy).forEach(([runId, result]) => {
+    Object.entries(result.iterations).forEach(([iterationId, iteration]) => {
+      Object.entries(iteration.samples).forEach(([, sample]) => {
+        const match =
+          _.isMatch(sample.sample, selectedParams) || _.isMatch(sample.benchmark, selectedParams);
+        if (match === false) {
+          delete resultsCopy[runId].iterations[iterationId];
         }
       });
-      iterationMetadata = {
-        ...iterationMetadata,
-        ...iteration.iteration_data.parameters.benchmark[0],
-      };
+    });
+  });
 
-      if (iteration.iteration_name.includes('fail') || !iterationConfig) {
+  return resultsCopy;
+};
+
+export const generateClusters = results => {
+  const iterations = {};
+  const clusterGraphKeys = new Set();
+  const params = new Set();
+
+  Object.entries(results).forEach(([runId, result]) => {
+    Object.entries(result.iterations).forEach(([, iteration]) => {
+      Object.entries(iteration.samples).forEach(([sampleId, sample]) => {
+        Object.keys(sample.benchmark).forEach(param => params.add(param));
+        const paramKey = Object.values(sample.benchmark).join('-');
+        const primaryMetric = sampleId.split('-')[0];
+
+        if (primaryMetric === sample.benchmark.primary_metric.toLowerCase()) {
+          iterations[paramKey] = {
+            ...iterations[paramKey],
+            ...sample.benchmark,
+            cluster: {
+              ...(iterations[paramKey] !== undefined && iterations[paramKey].cluster),
+              [`${runId}`]: sample.sample.mean,
+              [`name_${runId}`]: sample.sample.name,
+              [`percent_${runId}`]: sample.sample.stddevpct,
+              cluster: paramKey,
+            },
+            [runId]: {
+              sample: sample.sample,
+              run: sample.run,
+              benchmark: sample.benchmark,
+            },
+          };
+          clusterGraphKeys.add(`${runId}`);
+        }
+      });
+    });
+  });
+
+  const clusters = _.groupBy(Object.values(iterations), 'primary_metric');
+  Object.entries(clusters).forEach(([, cluster]) => {
+    Object.entries(cluster).forEach(([clusterId, data]) => {
+      // eslint-disable-next-line no-param-reassign
+      data.cluster.cluster = Number.parseInt(clusterId, 10) + 1;
+    });
+  });
+
+  return {
+    data: clusters,
+    keys: clusterGraphKeys,
+    params,
+  };
+};
+
+export const generateSampleTable = response => {
+  const runs = {};
+  let iterationParams = {};
+  const paramBlacklist = [
+    '@idx',
+    'description',
+    'end',
+    'max_stddevpct',
+    'mean',
+    'measurement_idx',
+    'name',
+    'start',
+    'stddev',
+    'stddevpct',
+    'uid_tmpl',
+  ];
+
+  const benchmarkBlacklist = ['clients', 'servers', 'uid', 'version', 'uid_tmpl'];
+
+  response.forEach(run => {
+    const iterations = {};
+    const id = run.aggregations.id.buckets[0].key;
+    const primaryMetrics = new Set();
+    run.hits.hits.forEach(sample => {
+      // eslint-disable-next-line no-underscore-dangle
+      const source = sample._source;
+      if (source.iteration.name.includes('fail')) {
         return;
       }
+      const sampleSource = _.omit({ ...source.benchmark, ...source.sample }, paramBlacklist);
 
-      Object.entries(iteration.iteration_data).forEach(([iterationType, iterationNetworkData]) => {
-        let iterationTypeColumnIndex = _.findIndex(columns, { title: iterationType });
-        if (iterationType !== 'parameters' && iterationTypeColumnIndex) {
-          if (!_.includes(columns[iterationTypeColumnIndex], iterationType)) {
-            columns.push({ title: iterationType });
-          }
-        } else {
-          return;
+      // Aggregate iteration params
+      iterationParams = _.mergeWith(iterationParams, sampleSource, (objVal, srcVal) => {
+        if (objVal !== undefined) {
+          const uniqParams = _.uniq([...objVal, ...[srcVal]]);
+          return uniqParams;
         }
+        return [srcVal];
+      });
 
-        Object.entries(iterationNetworkData).forEach(([iterationNetwork, iterationData]) => {
-          // Find iteration type column and create or append iteration network child entry
-          iterationTypeColumnIndex = _.findIndex(columns, { title: iterationType });
-          if (_.has(columns[iterationTypeColumnIndex], 'children')) {
-            if (!_.some(columns[iterationTypeColumnIndex].children, { title: iterationNetwork })) {
-              columns[iterationTypeColumnIndex].children.push({ title: iterationNetwork });
-            }
-          } else {
-            columns[iterationTypeColumnIndex].children = [{ title: iterationNetwork }];
-          }
+      // Aggregate iteration samples
+      const sampleData = {};
+      const sampleFields = source.sample;
+      const benchmarkFields = source.benchmark;
+      const runFields = source.run;
+      const iterationFields = source.iteration;
 
-          iterationData.forEach(hostMetadata => {
-            let columnHost = [];
-            if (hostMetadata.client_hostname) {
-              columnHost.push(`client_hostname:${hostMetadata.client_hostname}`);
-            }
-            if (hostMetadata.server_hostname) {
-              columnHost.push(`server_hostname:${hostMetadata.server_hostname}`);
-            }
-            if (hostMetadata.server_port) {
-              columnHost.push(`server_port:${hostMetadata.server_port}`);
-            }
-            columnHost = columnHost.join('-');
+      const primaryMetric = `${sampleFields.measurement_title}`.toLowerCase();
+      const measurementField = `${sampleFields.measurement_type}-${primaryMetric}`.toLowerCase();
+      primaryMetrics.add(primaryMetric);
+      const samplePrefix = [measurementField, sampleFields.uid].join('-').toLowerCase();
 
-            const columnPrefix = `${iterationType}-${iterationNetwork}-${columnHost}`;
-            const columnMean = `${columnPrefix}-mean`;
-            const columnStdDev = `${columnPrefix}-stddevpct`;
-            const columnSample = `${columnPrefix}-closestsample`;
+      sampleData[`${samplePrefix}-closest_sample`] = sampleFields.closest_sample;
+      sampleData[`${samplePrefix}-mean`] = sampleFields.mean;
+      sampleData[`${samplePrefix}-stddevpct`] = sampleFields.stddevpct;
+      iterationFields.closest_sample = sampleFields.closest_sample;
 
-            // Find iteration network column and create or append iteration column child entry
-            const iterationTypeColumn = columns[iterationTypeColumnIndex].children;
-            const iterationNetworkColumnIndex = _.findIndex(iterationTypeColumn, {
-              title: iterationNetwork,
-            });
-            if (!iterationPorts.includes(columnHost)) {
-              iterationPorts.push(columnHost);
-            }
-            if (_.has(iterationTypeColumn[iterationNetworkColumnIndex], 'children')) {
-              if (
-                !_.some(iterationTypeColumn[iterationNetworkColumnIndex].children, {
-                  dataIndex: columnPrefix,
-                })
-              ) {
-                iterationTypeColumn[iterationNetworkColumnIndex].children.push({
-                  title: columnHost,
-                  dataIndex: columnPrefix,
-                });
-              }
-            } else {
-              iterationTypeColumn[iterationNetworkColumnIndex].children = [
-                { title: columnHost, dataIndex: columnPrefix },
-              ];
-            }
+      iterations[source.iteration.name] = {
+        ...iterations[source.iteration.name],
+        ...iterationFields,
+        ...sampleData,
+        samples: {
+          ...(iterations[source.iteration.name] !== undefined &&
+            iterations[source.iteration.name].samples),
+          ...(sampleFields.closest_sample === sampleFields['@idx'] + 1 && {
+            [`${primaryMetric}-${sampleFields.name}`]: {
+              sample: { ...sampleFields },
+              benchmark: _.omit({ ...benchmarkFields }, benchmarkBlacklist),
+              run: { ...runFields },
+            },
+          }),
+        },
+      };
+    });
 
-            const dataIndexColumn = iterationTypeColumn[iterationNetworkColumnIndex].children;
-            const dataIndexColumnIndex = _.findIndex(
-              columns[iterationTypeColumnIndex].children[iterationNetworkColumnIndex].children,
-              { title: columnHost }
-            );
-            const columnMeanData = {
-              title: 'mean',
-              dataIndex: columnMean,
-              key: columnMean,
-              sorter: (a, b) => a[columnMean] - b[columnMean],
+    run.aggregations.id.buckets.forEach(runId => {
+      const iterationColumnsData = [
+        {
+          title: 'Iteration Name',
+          dataIndex: 'name',
+          key: 'name',
+        },
+      ];
+      runId.type.buckets.forEach(type => {
+        iterationColumnsData.push({
+          title: type.key,
+          children: type.title.buckets.map(title => {
+            return {
+              title: title.key,
+              children: title.uid.buckets.map(uid => {
+                return {
+                  title: `${type.key}-${title.key}-${uid.key}`,
+                  children: [
+                    {
+                      title: 'mean',
+                      dataIndex: `${type.key}-${title.key}-${uid.key}-mean`,
+                      key: `${type.key}-${title.key}-${uid.key}-mean`,
+                    },
+                    {
+                      title: 'stddevpct',
+                      dataIndex: `${type.key}-${title.key}-${uid.key}-stddevpct`,
+                      key: `${type.key}-${title.key}-${uid.key}-stddevpct`,
+                    },
+                    {
+                      title: 'closest_sample',
+                      dataIndex: `${type.key}-${title.key}-${uid.key}-closest_sample`,
+                      key: `${type.key}-${title.key}-${uid.key}-closest_sample`,
+                    },
+                  ],
+                };
+              }),
             };
-            const columnStdDevData = {
-              title: 'stddevpct',
-              dataIndex: columnStdDev,
-              key: columnStdDev,
-              sorter: (a, b) => a[columnStdDev] - b[columnStdDev],
-            };
-            const columnSampleData = {
-              title: 'closest sample',
-              dataIndex: columnSample,
-              key: columnSample,
-              sorter: (a, b) => a[columnSample] - b[columnSample],
-            };
-
-            if (_.has(dataIndexColumn[dataIndexColumnIndex], 'children')) {
-              if (
-                !_.some(dataIndexColumn[dataIndexColumnIndex].children, { dataIndex: columnMean })
-              ) {
-                dataIndexColumn[dataIndexColumnIndex].children.push(columnMeanData);
-              }
-              if (
-                !_.some(dataIndexColumn[dataIndexColumnIndex].children, { dataIndex: columnStdDev })
-              ) {
-                dataIndexColumn[dataIndexColumnIndex].children.push(columnStdDevData);
-              }
-              if (
-                !_.some(dataIndexColumn[dataIndexColumnIndex].children, { dataIndex: columnSample })
-              ) {
-                dataIndexColumn[dataIndexColumnIndex].children.push(columnSampleData);
-              }
-            } else {
-              dataIndexColumn[dataIndexColumnIndex].children = [
-                columnMeanData,
-                columnStdDevData,
-                columnSampleData,
-              ];
-            }
-            iterationMetadata[columnMean] = hostMetadata.mean;
-            iterationMetadata[columnStdDev] = hostMetadata.stddevpct;
-            const iterationClosestSample =
-              typeof hostMetadata.closest_sample !== 'undefined'
-                ? hostMetadata.closest_sample
-                : hostMetadata['closest sample'];
-            iterationMetadata[columnSample] = iterationClosestSample;
-            iterationMetadata.closest_sample = iterationClosestSample;
-          });
+          }),
         });
       });
-      parsedResponse.iterations.push(iterationMetadata);
+      runs[runId.key] = { columns: iterationColumnsData };
     });
-    parsedResponse.iterations.sort((a, b) => a.iteration_number - b.iteration_number);
-    parsedResponse.resultName = result.resultName;
-    parsedResponse.controllerName = result.controllerName;
-    parsedResponse.columns = columns;
-    iterations.push(parsedResponse);
+    runs[id] = {
+      ...runs[id],
+      run_name: run.aggregations.name.buckets[0].key,
+      run_controller: run.aggregations.controller.buckets[0].key,
+      iterations,
+      id,
+      primaryMetrics,
+    };
   });
-  iterationPorts.sort();
-
   return {
-    iterations,
-    selectedIterationKeys,
+    runs,
     iterationParams,
-    iterationPorts,
   };
-};
-
-const cloneResultsData = results => {
-  const resultsCopy = [];
-
-  results.forEach((result, index) => {
-    resultsCopy[index] = {};
-    resultsCopy[index].columns = _.cloneDeep(result.columns);
-    resultsCopy[index].iterations = _.cloneDeep(result.iterations);
-    resultsCopy[index].resultName = result.resultName;
-    resultsCopy[index].controllerName = result.controllerName;
-  });
-
-  return resultsCopy;
-};
-
-const removeColumnKey = (column, ports) => {
-  if (
-    column &&
-    column.title &&
-    (column.title.includes('port') || column.title.includes('hostname'))
-  ) {
-    let portFound = false;
-    ports.forEach(port => {
-      if (column.title === port) {
-        portFound = true;
-      }
-    });
-    if (!portFound) {
-      delete column.title;
-      delete column.dataIndex;
-      delete column.children;
-      return column;
-    }
-    return column;
-  }
-  if (column && column.children && column.children.length > 0) {
-    const filteredChildren = [];
-    column.children.forEach(columnChild => {
-      const filteredChild = removeColumnKey(columnChild, ports);
-      if (!_.isEmpty(filteredChild)) {
-        filteredChildren.push(filteredChild);
-      }
-    });
-    column.children = filteredChildren;
-    return column;
-  }
-  return column;
-};
-
-const filterColumns = (columns, ports) => {
-  const filteredColumn = [];
-  columns.forEach(column => {
-    filteredColumn.push(removeColumnKey(column, ports));
-  });
-  return filteredColumn;
-};
-
-export const filterIterations = (results, selectedParams, selectedPorts) => {
-  const resultsCopy = cloneResultsData(results);
-
-  resultsCopy.forEach((result, index) => {
-    const filteredColumns = filterColumns(result.columns, selectedPorts);
-
-    const filteredIterations = [];
-    result.iterations.forEach(iteration => {
-      if (_.isMatch(iteration, selectedParams)) {
-        filteredIterations.push(iteration);
-      }
-    });
-    resultsCopy[index].columns = filteredColumns;
-    resultsCopy[index].iterations = filteredIterations;
-  });
-
-  return resultsCopy;
-};
-
-export const filterIterationColumns = (results, selectedPorts) => {
-  const resultsCopy = cloneResultsData(results);
-
-  resultsCopy.forEach((result, index) => {
-    selectedPorts.forEach(port => {
-      resultsCopy[index].columns = filterColumns(result.columns, port);
-    });
-  });
-
-  return resultsCopy;
-};
-
-export const parseClusteredIterations = (clusteredIterations, clusterLabels, selectedConfig) => {
-  const clusteredGraphData = [];
-  const graphKeys = [];
-  const tableData = [];
-  let maxIterationLength = 0;
-
-  Object.keys(clusteredIterations).forEach(primaryMetric => {
-    clusteredGraphData[primaryMetric] = [];
-    graphKeys[primaryMetric] = [];
-    tableData[primaryMetric] = [];
-    let maxClusterLength = 0;
-    Object.keys(clusteredIterations[primaryMetric]).forEach(cluster => {
-      const clusterObject = { cluster };
-      const meanValues = [];
-      Object.keys(clusteredIterations[primaryMetric][cluster]).forEach(iteration => {
-        clusterObject[iteration] =
-          clusteredIterations[primaryMetric][cluster][iteration][
-            Object.keys(clusteredIterations[primaryMetric][cluster][iteration]).find(key => {
-              if (key.includes('all') && key.includes('mean') && key.includes(primaryMetric)) {
-                return key;
-              }
-              return false;
-            })
-          ];
-        meanValues.push(clusterObject[iteration]);
-        let percentage = 0;
-        if (iteration !== 0) {
-          percentage =
-            ((clusterObject[iteration] - clusterObject[0]) /
-              ((clusterObject[iteration] + clusterObject[0]) / 2)) *
-            100;
-        }
-        clusterObject[`percent${iteration}`] = percentage.toFixed(1);
-        if (meanValues.length > maxIterationLength) {
-          maxIterationLength = meanValues.length;
-        }
-        clusterObject[`name${iteration}`] =
-          clusteredIterations[primaryMetric][cluster][iteration].iteration_name;
-      });
-      clusteredGraphData[primaryMetric].push(clusterObject);
-      const clusterItems = Object.keys(clusterObject).length - 1;
-      if (clusterItems > maxClusterLength) {
-        maxClusterLength = clusterItems;
-      }
-      tableData[primaryMetric].push({
-        key: cluster,
-        clusterID: cluster,
-        cluster: clusterLabels[primaryMetric][cluster],
-        primaryMetric,
-        length: clusterItems,
-      });
-    });
-    for (let i = 0; i < maxClusterLength; i += 1) {
-      graphKeys[primaryMetric].push(i);
-    }
-  });
-  return {
-    tableData,
-    graphKeys,
-    clusteredGraphData,
-    maxIterationLength,
-    clusteredIterations,
-    selectedConfig,
-  };
-};
-
-export const groupClusters = (array, cluster, f) => {
-  const groups = {};
-
-  array.forEach(o => {
-    const group = f(o).join('-');
-    groups[group] = groups[group] || [];
-    groups[group].push(o);
-  });
-
-  return {
-    clusterLabels: Object.keys(groups),
-    cluster: Object.keys(groups).map(group => groups[group]),
-  };
-};
-
-export const generateIterationClusters = (config, iterations) => {
-  let primaryMetricIterations = [];
-  let clusteredIterations = [];
-  const clusterLabels = [];
-  const selectedConfig = config;
-
-  primaryMetricIterations = _.mapValues(_.groupBy(iterations, 'primary_metric'), clist =>
-    clist.map(iteration => _.omit(iteration, 'primary_metric'))
-  );
-
-  Object.keys(primaryMetricIterations).forEach(cluster => {
-    clusteredIterations = [];
-    if (typeof config === 'object' && config.length > 0) {
-      clusteredIterations = groupClusters(primaryMetricIterations[cluster], cluster, item => {
-        const configData = [];
-        config.forEach(filter => {
-          configData.push(item[filter]);
-        });
-        return configData;
-      });
-    } else {
-      clusteredIterations = _.mapValues(
-        _.groupBy(primaryMetricIterations[cluster], config),
-        clist => clist.map(iteration => _.omit(iteration, config))
-      );
-    }
-    primaryMetricIterations[cluster] = clusteredIterations.cluster;
-    clusterLabels[cluster] = clusteredIterations.clusterLabels;
-  });
-
-  return parseClusteredIterations(primaryMetricIterations, clusterLabels, selectedConfig);
-};
-
-export const getComparisonColumn = maxIterationLength => {
-  const children = [];
-  for (let i = 0; i < maxIterationLength; i += 1) {
-    children.push({
-      title: `Iteration - ${i}`,
-      dataIndex: `Iteration-${i}`,
-      key: `Iteration${i}`,
-      children: [
-        {
-          title: 'Name',
-          dataIndex: `name${i}`,
-          key: `name${i}`,
-          width: 250,
-          render: text => {
-            if (text === undefined) {
-              return {
-                props: {
-                  style: { background: '#e8e8e8' },
-                },
-              };
-            }
-            return <div>{text}</div>;
-          },
-        },
-        {
-          title: 'Mean',
-          dataIndex: i,
-          key: `mean${i}`,
-          width: 250,
-          render: text => {
-            if (text === undefined) {
-              return {
-                props: {
-                  style: { background: '#e8e8e8' },
-                },
-              };
-            }
-            return <div>{text}</div>;
-          },
-        },
-        {
-          title: 'Percent',
-          dataIndex: `percent${i}`,
-          key: `percent${i}`,
-          width: 0,
-          render: text => {
-            if (text > 0) {
-              return (
-                <div style={{ textAlign: 'right' }}>
-                  {`${text}%`}
-                  <Icon
-                    type="caret-up"
-                    theme="filled"
-                    style={{ marginLeft: '3%', color: 'green' }}
-                  />
-                </div>
-              );
-            }
-            if (text < 0) {
-              return (
-                <div style={{ textAlign: 'right' }}>
-                  {`${Math.abs(text)}%`}
-                  <Icon
-                    type="caret-down"
-                    theme="filled"
-                    style={{ marginLeft: '3%', color: 'red' }}
-                  />
-                </div>
-              );
-            }
-            if (text === undefined) {
-              return {
-                props: {
-                  style: { background: '#e8e8e8' },
-                },
-              };
-            }
-            return (
-              <div>
-                <Icon type="dash" style={{ color: 'red' }} />
-              </div>
-            );
-          },
-        },
-      ],
-    });
-  }
-  const column = [
-    {
-      title: 'Cluster',
-      dataIndex: 'cluster',
-      key: 'cluster',
-      width: 150,
-      fixed: 'left',
-      render: text => `cluster - ${text}`,
-    },
-    {
-      title: 'Iteration',
-      children,
-    },
-  ];
-  return column;
 };

--- a/src/utils/parse.test.js
+++ b/src/utils/parse.test.js
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+import { generateSampleTable, generateClusters } from './parse';
+import { mockDataSample, expectedSampleData, expectedClusterData } from '../../mock/api';
+
+describe('test generateSampleTable', () => {
+  const parsedSampleTable = generateSampleTable(mockDataSample);
+  it('should generate sample table data', () => {
+    expect(Object.keys(parsedSampleTable).length > 0);
+  });
+  it('should equal mocked sample table data', () => {
+    expect(_.isEqual(parsedSampleTable, expectedSampleData));
+  });
+});
+
+describe('test generateClusters', () => {
+  const parsedClusterData = generateClusters(
+    expectedSampleData.runs,
+    expectedSampleData.iterationParams
+  );
+  it('should generate cluster data', () => {
+    expect(Object.keys(parsedClusterData).length > 0);
+  });
+  it('should equal mocked cluster data', () => {
+    expect(_.isEqual(parsedClusterData, expectedClusterData));
+  });
+});

--- a/unittests
+++ b/unittests
@@ -1,6 +1,19 @@
 #!/bin/bash
 
 cd $(dirname ${0})
+
+# Setup the mock'd data store configuration.
+cat > mock/datastoreConfig.js <<EOF
+export default {
+  '/dev/datastoreConfig': {
+    elasticsearch: 'http://test_domain.com',
+    results: 'http://test_domain.com',
+    graphql: 'http://test_domain.com',
+    prefix: 'test_prefix.',
+    run_index: 'test_index.',
+  },
+};
+EOF
 yarn install --network-timeout 1000000
 if [[ ${?} -ne 0 ]]; then
   echo "yarn install failed!" >&2


### PR DESCRIPTION
Phase one of result-data index migration represents changes to
postprocessing when handling run iteration & sample data. Data from the new index is now being processed and visualized within the `ComparisonSelect`, `RunComparison,` and `Summary` page components. 

Queries are made to the new Elasticsearch index whereas previously queries were made to
result.json files on the production results server.

Phase two will represent changes to timeseries data retrieval, visualization, and UX updates to cluster legends, tables, and percent change graphs using Patternfly. 

Notable changes:
- `result-index` key in dashboard config references new index
- postprocessing of iteration & sample data now occurs within redux action flow
- implementation of cluster generation using ES6 object spread & object literals