### PR TITLE
Redirect user to 404 page when 404 error code received from request handler

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -35,7 +35,7 @@ const errorHandler = error => {
     return;
   }
   if (status === 404) {
-    router.goBack();
+    router.push('/exception/404');
     return;
   }
   if (status <= 504 && status >= 500) {


### PR DESCRIPTION
By utilizing the `Exception` page component handler, we avoid sending the user outside of the routing history of the dashboard in cases where 404 errors are identified within starting points of the dashboard (`Controller`, `Search`, and `Explore` pages).