### PR TITLE
Verify dashboard version before rehydrating redux store during deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "precommit": "npm run lint-staged",
     "start": "cross-env UMI_UI=none umi dev",
     "start:no-mock": "cross-env MOCK=none umi dev",
-    "build": "umi build",
+    "build": "npm --no-git-tag-version version prerelease && umi build",
     "site": "umi-api-doc static && gh-pages -d dist",
     "analyze": "cross-env ANALYZE=true umi build",
     "lint:style": "stylelint \"src/**/*.less\" --syntax less",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+import { version } from '../package.json';
 import { getAppPath } from './utils/utils';
 
 /*
@@ -18,8 +19,15 @@ const persistConfig = {
 };
 
 const persistEnhancer = () => createStore => (reducer, initialState, enhancer) => {
+  const cachedVersionId = window.localStorage.getItem('versionId');
+  if (cachedVersionId && cachedVersionId !== version && process.env.NODE_ENV === 'production') {
+    window.localStorage.clear();
+  }
+  window.localStorage.setItem('versionId', version);
+
   const store = createStore(persistReducer(persistConfig, reducer), initialState, enhancer);
   const persist = persistStore(store, null);
+
   return {
     persist,
     ...store,


### PR DESCRIPTION
Previously, new deployments to staging and production environments were causing issues with rendering the dashboard in cases where persisted data became invalid due to changes in data availability. 

By incrementing the package version number before deployments, we can verify whether a new deployment is in place before either rehydrating or invalidating the redux store.