### PR TITLE
Install and setup patternfly

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@antv/g2": "^3.4.10",
     "@babel/runtime": "^7.3.1",
     "@nivo/bar": "^0.36.0",
+    "@patternfly/react-core": "^3.158.1",
+    "@patternfly/react-icons": "^3.15.17",
     "ant-design-pro": "^2.1.1",
     "antd": "^3.16.1",
     "classnames": "^2.2.5",

--- a/src/global.js
+++ b/src/global.js
@@ -1,3 +1,4 @@
 import './polyfill';
 import './global.less';
 import 'ant-design-pro/dist/ant-design-pro.css';
+import '@patternfly/react-core/dist/styles/base.css';


### PR DESCRIPTION
This PR  installs and sets up patternfly for the dashboard.

## Motivation
Since we are moving towards "patternfly" for all our UI components, it was necessary to get it installed first rather than trying out all those features that would require patternfly as a dependency to be installed first. This will keep other people unblocked of their works.