### PR TITLE
run session e2e tests in headless browser

### DIFF
--- a/src/e2e/session.e2e.js
+++ b/src/e2e/session.e2e.js
@@ -6,8 +6,7 @@ let page;
 
 beforeAll(async () => {
   browser = await puppeteer.launch({
-    headless: false,
-    slowMo: 100,
+    headless: true,
     args: ['--no-sandbox'],
   });
   page = await browser.newPage();


### PR DESCRIPTION
The motivation behind this PR is as follows:
- Running e2e tests in a browser won't be of use in a CI/CD like Travis.
- Running tests using `slowMo` property will slow down the test results.