### PR TITLE
Dashboard APIs

### DIFF
--- a/src/services/datastore.js
+++ b/src/services/datastore.js
@@ -29,7 +29,9 @@ export async function queryDatastoreConfig() {
 export async function queryMonthIndices(params) {
   const { datastoreConfig } = params;
 
-  const endpoint = `${datastoreConfig.elasticsearch}/_aliases`;
+  const indices = `/_aliases`;
 
-  return request.get(endpoint);
+  const endpoint = `${datastoreConfig.pbench_server}/elasticsearch`;
+
+  return request.post(endpoint, { data: { indices } });
 }

--- a/src/services/explore.js
+++ b/src/services/explore.js
@@ -4,7 +4,7 @@ import request from '../utils/request';
 export async function querySharedSessions(params) {
   const { datastoreConfig } = params;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+  const endpoint = `${datastoreConfig.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {
@@ -25,7 +25,7 @@ export async function querySharedSessions(params) {
 export async function updateDescription(params) {
   const { datastoreConfig, id, value } = params;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+  const endpoint = `${datastoreConfig.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {
@@ -52,7 +52,7 @@ export async function updateDescription(params) {
 export async function deleteSharedSessions(params) {
   const { datastoreConfig, id } = params;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+  const endpoint = `${datastoreConfig.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -4,56 +4,61 @@ import request from '../utils/request';
 export async function queryIndexMapping(params) {
   const { datastoreConfig, indices } = params;
 
-  const endpoint = `${datastoreConfig.elasticsearch}/${datastoreConfig.prefix}${
-    datastoreConfig.run_index
-  }${indices[0]}/_mappings`;
+  const url = `/${datastoreConfig.prefix}${datastoreConfig.run_index}${indices[0]}/_mappings`;
 
-  return request.get(endpoint);
+  const endpoint = `${datastoreConfig.pbench_server}/elasticsearch`;
+
+  return request.post(endpoint, { data: { indices: url } });
 }
 
 export async function searchQuery(params) {
   try {
     const { datastoreConfig, selectedFields, selectedDateRange, query } = params;
 
-    const endpoint = `${datastoreConfig.elasticsearch}/${getAllMonthsWithinRange(
+    const indices = `/${getAllMonthsWithinRange(
       datastoreConfig,
       datastoreConfig.run_index,
       selectedDateRange
     )}/_search`;
 
+    const endpoint = `${datastoreConfig.pbench_server}/elasticsearch`;
+
     return request.post(endpoint, {
-      params: {
-        ignore_unavailable: true,
-      },
       data: {
-        size: 10000,
-        filter: {
-          range: {
-            '@timestamp': {
-              gte: selectedDateRange.start,
-              lte: selectedDateRange.end,
-            },
-          },
+        indices,
+        params: {
+          ignore_unavailable: true,
         },
-        sort: [
-          {
-            '@timestamp': {
-              order: 'desc',
-              unmapped_type: 'boolean',
-            },
-          },
-        ],
-        query: {
-          filtered: {
-            query: {
-              query_string: {
-                query: `*${query}*`,
-                analyze_wildcard: true,
+        payload: {
+          size: 10000,
+          filter: {
+            range: {
+              '@timestamp': {
+                gte: selectedDateRange.start,
+                lte: selectedDateRange.end,
               },
             },
           },
+          sort: [
+            {
+              '@timestamp': {
+                order: 'desc',
+                unmapped_type: 'boolean',
+              },
+            },
+          ],
+          query: {
+            filtered: {
+              query: {
+                query_string: {
+                  query: `*${query}*`,
+                  analyze_wildcard: true,
+                },
+              },
+            },
+          },
+          fields: selectedFields,
         },
-        fields: selectedFields,
       },
     });
   } catch (error) {


### PR DESCRIPTION
Replaced all Elasticsearch calls to use pbench server APIs
Server address {pbench_server) needs to be specified in datastoreConfig.js to enable API calls
References for Elasticsearch and GraphQL from datastoreConfig.js have been moved to the server(pbench-server.cfg).