### PR TITLE
Update Apollo Server register mutation with firstName and lastName fields

### DIFF
--- a/prisma/src/resolvers.js
+++ b/prisma/src/resolvers.js
@@ -31,9 +31,11 @@ const resolvers = {
         user,
       };
     },
-    register: async (parent, { username, password }, ctx) => {
+    register: async (parent, { firstName, lastName, username, password }, ctx) => {
       const hashedPassword = await bcrypt.hash(password, 10);
       const user = await ctx.prisma.createUser({
+        firstName,
+        lastName,
         username,
         password: hashedPassword,
       });

--- a/prisma/src/typeDefs.js
+++ b/prisma/src/typeDefs.js
@@ -3,6 +3,8 @@ const { gql } = require('apollo-server');
 const typeDefs = gql`
   type User {
     id: ID!
+    firstName: String!
+    lastName: String!
     username: String!
   }
 
@@ -11,7 +13,7 @@ const typeDefs = gql`
   }
 
   type Mutation {
-    register(username: String!, password: String!): User!
+    register(firstName: String!, lastName: String!, username: String!, password: String!): User!
     login(username: String!, password: String!): LoginResponse!
   }
 


### PR DESCRIPTION
Apollo server registration mutation method requires firstName and lastName fields from user to successfully create User model.

The firstName and lastName fields are declared as part of the User data model in typeDefs.js and referenced within the mutation in resolvers.js.