### PR TITLE
human readable timestamps of last modified

### DIFF
--- a/src/e2e/controllers.e2e.js
+++ b/src/e2e/controllers.e2e.js
@@ -245,8 +245,9 @@ describe('controller page component', () => {
       '.ant-calendar-panel > .ant-calendar-footer > .ant-calendar-footer-btn > .ant-calendar-footer-extra > .ant-tag:nth-child(3)'
     );
 
-    await page.click(
-      '.ant-calendar-panel > .ant-calendar-footer > .ant-calendar-footer-btn > .ant-calendar-footer-extra > span.ant-tag.ant-tag-blue:nth-child(3)'
+    await page.$eval(
+      '.ant-calendar-panel > .ant-calendar-footer > .ant-calendar-footer-btn > .ant-calendar-footer-extra > span.ant-tag.ant-tag-blue:nth-child(3)',
+      elem => elem.click()
     );
     const startDate = await page.$eval(
       '.ant-card-body > .ant-form > .ant-calendar-picker > .ant-calendar-picker-input > .ant-calendar-range-picker-input:nth-child(1)',

--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import { Card, Form, Icon, Tabs } from 'antd';
+import { Card, Form, Icon, Tabs, Tooltip } from 'antd';
 
 import SearchBar from '@/components/SearchBar';
 import AntdDatePicker from '@/components/DatePicker';
 import Table from '@/components/Table';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import { getDiffDate } from '@/utils/moment_constants';
 
 const { TabPane } = Tabs;
 
@@ -157,6 +158,11 @@ class Controllers extends Component {
         dataIndex: 'last_modified_string',
         key: 'last_modified_string',
         sorter: (a, b) => a.last_modified_value - b.last_modified_value,
+        render: val => (
+          <Tooltip title={val}>
+            <span>{getDiffDate(val)}</span>
+          </Tooltip>
+        ),
       },
       {
         title: 'Results',

--- a/src/pages/Explore/index.js
+++ b/src/pages/Explore/index.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import { Card, Button, Popconfirm, Icon, Form, Modal, Input } from 'antd';
+import { Card, Button, Popconfirm, Icon, Form, Modal, Input, Tooltip } from 'antd';
 
 import Table from '@/components/Table';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import { getDiffDate } from '@/utils/moment_constants';
 
 const { TextArea } = Input;
 
@@ -125,6 +126,11 @@ class Explore extends Component {
         key: 'createdAt',
         defaultSortOrder: 'descend',
         sorter: (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
+        render: val => (
+          <Tooltip title={val}>
+            <span>{getDiffDate(val)}</span>
+          </Tooltip>
+        ),
       },
       {
         title: 'Description',

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import { Card, Form, Icon, Tabs } from 'antd';
+import { Card, Form, Icon, Tabs, Tooltip } from 'antd';
 
 import SearchBar from '@/components/SearchBar';
 import RowSelection from '@/components/RowSelection';
 import Table from '@/components/Table';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import { getDiffDate } from '@/utils/moment_constants';
 
 const { TabPane } = Tabs;
 
@@ -166,11 +167,21 @@ class Results extends Component {
         dataIndex: 'run.start',
         key: 'run.start',
         sorter: (a, b) => a.startUnixTimestamp - b.startUnixTimestamp,
+        render: val => (
+          <Tooltip title={val}>
+            <span>{getDiffDate(val)}</span>
+          </Tooltip>
+        ),
       },
       {
         title: 'End Time',
         dataIndex: 'run.end',
         key: 'run.end',
+        render: val => (
+          <Tooltip title={val}>
+            <span>{getDiffDate(val)}</span>
+          </Tooltip>
+        ),
       },
       {
         title: 'Actions',

--- a/src/utils/moment_constants.js
+++ b/src/utils/moment_constants.js
@@ -36,3 +36,7 @@ export function getAllMonthsWithinRange(datastoreConfig, index, selectedDateRang
   });
   return queryString;
 }
+
+export const getDiffDate = givenDate => {
+  return moment(givenDate).fromNow();
+};


### PR DESCRIPTION
Making timestamps human readable across the dashboard. I will move forward with further implementations in other pages if this PR actually makes sense to the team as well. Fixes #73.

Note:
Tooltips provided by `patternfly` are incompatible with `antd table`. We need to keep this in mind when we migrate completely to the `patternfly` table implementation, we have to use the tooltip by patternfly as well. 

## Demo

<img width="1359" alt="Screenshot 2020-08-17 at 4 03 34 PM" src="https://user-images.githubusercontent.com/26324376/90387405-b89fe880-e0a3-11ea-8e15-699c87d0017b.png">