### PR TITLE
use react memo in place of memoize-one

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "jspdf": "^1.5.3",
     "lodash": "^4.17.10",
     "lodash-decorators": "^6.0.0",
-    "memoize-one": "^5.0.0",
     "moment": "^2.24.0",
     "numeral": "^2.0.6",
     "omit.js": "^1.0.0",

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { Layout, Icon, Spin, message } from 'antd';
 import DocumentTitle from 'react-document-title';
@@ -10,8 +10,6 @@ import { ContainerQuery } from 'react-container-query';
 import classNames from 'classnames';
 import pathToRegexp from 'path-to-regexp';
 import { enquireScreen, unenquireScreen } from 'enquire-js';
-import memoizeOne from 'memoize-one';
-import deepEqual from 'lodash/isEqual';
 import GlobalFooter from 'ant-design-pro/lib/GlobalFooter';
 import GlobalHeader from '@/components/GlobalHeader';
 import SiderMenu from '../components/SiderMenu';
@@ -36,7 +34,7 @@ const getRedirect = item => {
 };
 getMenuData().forEach(getRedirect);
 
-const getBreadcrumbNameMap = memoizeOne(menu => {
+const getBreadcrumbNameMap = menu => {
   const routerMap = {};
   const mergeMeunAndRouter = menuData => {
     menuData.forEach(menuItem => {
@@ -49,7 +47,7 @@ const getBreadcrumbNameMap = memoizeOne(menu => {
   };
   mergeMeunAndRouter(menu);
   return routerMap;
-}, deepEqual);
+};
 
 const query = {
   'screen-xs': {
@@ -103,7 +101,7 @@ class BasicLayout extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.getPageTitle = memoizeOne(this.getPageTitle);
+    this.getPageTitle = this.getPageTitle;
     this.breadcrumbNameMap = getBreadcrumbNameMap(getMenuData());
     // eslint-disable-next-line no-underscore-dangle
     this.persistor = persistStore(window.g_app._store);
@@ -280,4 +278,4 @@ class BasicLayout extends React.PureComponent {
   }
 }
 
-export default BasicLayout;
+export default memo(BasicLayout);


### PR DESCRIPTION
Fixes #13.

Notice the following from React's documentation:
```
React.memo only checks for prop changes. 
If your function component wrapped in React.memo has a useState 
or useContext Hook in its implementation, it will still rerender when state or context change.
```

So, what I think is when we change across routes in our dashboard, components won't re-render again and again, because props would be essentially the same. @gurbirkalsi What do you think?