### PR TITLE
reference url in the prisma data model

### DIFF
--- a/prisma/.gitignore
+++ b/prisma/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+generated/

--- a/prisma/README.md
+++ b/prisma/README.md
@@ -42,6 +42,13 @@ npm install -g prisma
 # yarn global add prisma
 ```
 
+### Generating schema from the datamodel
+
+Prisma automatically handles schema generation from a given data model, you can do that by running
+`prisma generate` on your terminal in the `prisma/` directory. The generated files will be placed in the
+`generated/` directory. You must not change this file manually and you need to re-run the `prisma generate`
+command after every change that's made to your Prisma schema to update the generated Prisma Client code.
+
 #### Step 3: Deploy the Prisma datamodel
 
 ```bash

--- a/prisma/datamodel.prisma
+++ b/prisma/datamodel.prisma
@@ -8,8 +8,8 @@ type User {
 
 type Url {
   id: ID! @id
-  createdAt: DateTime! @createdAt
-  updatedAt: DateTime! @updatedAt
+  created: DateTime!
+  updated: DateTime!
   config: String!
   description: String
 }

--- a/prisma/src/resolvers.js
+++ b/prisma/src/resolvers.js
@@ -1,7 +1,25 @@
 const bcrypt = require('bcryptjs');
+const { GraphQLScalarType } = require('graphql');
+const { Kind } = require('graphql/language');
 const jwt = require('jsonwebtoken');
 
 const resolvers = {
+  DateTime: new GraphQLScalarType({
+    name: 'DateTime',
+    description: 'Date custom scalar type',
+    parseValue(value) {
+      return new Date(value); // value from the client
+    },
+    serialize(value) {
+      return new Date(value); // value sent to the client
+    },
+    parseLiteral(ast) {
+      if (ast.kind === Kind.INT) {
+        return parseInt(ast.value, 10); // ast value is always in string format
+      }
+      return null;
+    },
+  }),
   Mutation: {
     login: async (parent, { username, password }, ctx) => {
       const user = await ctx.prisma.user({ username });
@@ -40,6 +58,15 @@ const resolvers = {
         password: hashedPassword,
       });
       return user;
+    },
+    createUrl: async (parent, { created, updated, config, description }, ctx) => {
+      const url = await ctx.prisma.createUrl({
+        created,
+        updated,
+        config,
+        description,
+      });
+      return url;
     },
   },
 };

--- a/prisma/src/typeDefs.js
+++ b/prisma/src/typeDefs.js
@@ -1,11 +1,21 @@
 const { gql } = require('apollo-server');
 
 const typeDefs = gql`
+  scalar DateTime
+
   type User {
     id: ID!
     firstName: String!
     lastName: String!
     username: String!
+  }
+
+  type Url {
+    id: ID!
+    created: DateTime!
+    updated: DateTime!
+    config: String!
+    description: String
   }
 
   type Query {
@@ -15,6 +25,7 @@ const typeDefs = gql`
   type Mutation {
     register(firstName: String!, lastName: String!, username: String!, password: String!): User!
     login(username: String!, password: String!): LoginResponse!
+    createUrl(created: DateTime!, updated: DateTime!, config: String!, description: String!): Url!
   }
 
   type LoginResponse {

--- a/src/pages/Explore/index.js
+++ b/src/pages/Explore/index.js
@@ -131,8 +131,8 @@ class Explore extends Component {
       },
       {
         title: 'Date Created',
-        dataIndex: 'createdAt',
-        key: 'createdAt',
+        dataIndex: 'created',
+        key: 'created',
         defaultSortOrder: 'descend',
         sorter: (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
         render: val => (

--- a/src/services/explore.js
+++ b/src/services/explore.js
@@ -14,7 +14,7 @@ export async function querySharedSessions(params) {
               id
               config
               description
-              createdAt
+              created
           }   
         }`,
     },


### PR DESCRIPTION
Url was not referenced in the prisma data model due to which we were not able to add new urls of the sessions created in the `Explore` page. This PR is aimed at fixing #88 and #83 