### PR TITLE
Dashboard to work with Server APIs 

### DIFF
--- a/public/endpoints.js
+++ b/public/endpoints.js
@@ -1,7 +1,5 @@
 window.endpoints = {
-  elasticsearch: 'http://test_domain.com',
   results: 'http://test_domain.com',
-  graphql: 'http://test_domain.com',
   prefix: 'test_prefix.',
   run_index: 'vn.run-data.',
   run_toc_index: 'vn.run-toc.',

--- a/src/e2e/search.e2e.js
+++ b/src/e2e/search.e2e.js
@@ -33,7 +33,7 @@ beforeAll(async () => {
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(mockIndices),
       });
-    } else if (request.method() === 'GET' && request.url().includes('_mappings')) {
+    } else if (request.method() === 'POST' && request.postData().includes('mappings')) {
       request.respond({
         status: 200,
         contentType: 'application/json',

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -7,12 +7,11 @@ import { getAllMonthsWithinRange } from '../utils/moment_constants';
 const { endpoints } = window;
 
 function scrollUntilEmpty(data) {
-  const url = `/_search/scroll?scroll=1m`;
   const endpoint = `${endpoints.pbench_server}/elasticsearch`;
   const allData = data;
-  const indices = `_search/scroll?scroll=1m&scroll_id=${allData._scroll_id}`;
 
   if (allData.hits.total.value !== allData.hits.hits.length && allData._scroll_id) {
+    const indices = `_search/scroll?scroll=1m&scroll_id=${allData._scroll_id}`;
     const scroll = request.post(endpoint, {
       data: { indices },
     });
@@ -66,15 +65,15 @@ export async function queryResults(params) {
         payload: {
           _source: {
             includes: [
-                '@metadata.controller_dir',
-                '@metadata.satellite',
-                'run.controller',
-                'run.start',
-                'run.end',
-                'run.name',
-                'run.config',
-                'run.prefix',
-                'run.id',
+              '@metadata.controller_dir',
+              '@metadata.satellite',
+              'run.controller',
+              'run.start',
+              'run.end',
+              'run.name',
+              'run.config',
+              'run.prefix',
+              'run.id',
             ],
           },
           sort: {
@@ -166,7 +165,7 @@ export async function queryIterationSamples(params) {
           params: {
             ignore_unavailable: true,
           },
-          data: {
+          payload: {
             size: 1000,
             query: {
               match: {
@@ -186,7 +185,7 @@ export async function queryIterationSamples(params) {
                     aggs: {
                       title: {
                         terms: {
-                          field: 'sample.measurement_title',
+                          field: 'sample.measurement_title.raw',
                         },
                         aggs: {
                           uid: {
@@ -239,7 +238,7 @@ export async function queryIterationSamples(params) {
 export async function queryTimeseriesData(payload) {
   const { selectedDateRange, selectedIterations } = payload;
 
-  const indices = `${parseMonths(
+  const indices = `${getAllMonthsWithinRange(
     endpoints,
     endpoints.result_data_index,
     selectedDateRange
@@ -269,9 +268,9 @@ export async function queryTimeseriesData(payload) {
                         sample.sample.measurement_type
                       } AND sample.measurement_title:${
                         sample.sample.measurement_title
-                      } AND sample.measurement_idx:${sample.sample.measurement_idx} AND sample.name:${
-                        sample.sample.name
-                      }`,
+                      } AND sample.measurement_idx:${
+                        sample.sample.measurement_idx
+                      } AND sample.name:${sample.sample.name}`,
                       analyze_wildcard: true,
                     },
                   },

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -4,7 +4,8 @@ const { endpoints } = window;
 
 export async function saveUserSession(params) {
   const { sessionConfig, description } = params;
-  return request.post(endpoints.graphql, {
+  const endpoint = `${endpoints.pbench_server}/graphql`;
+  return request.post(endpoint, {
     data: {
       query: `
             mutation($config: String!, $description: String!) {
@@ -25,7 +26,8 @@ export async function saveUserSession(params) {
 
 export async function queryUserSession(params) {
   const { id } = params;
-  return request.post(endpoints.graphql, {
+  const endpoint = `${endpoints.pbench_server}/graphql`;
+  return request.post(endpoint, {
     data: {
       query: `
         query($id: ID!) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -4,7 +4,8 @@ const { endpoints } = window;
 
 export async function getSession(params) {
   const { sessionId } = params;
-  return request.post(endpoints.graphql, {
+  const endpoint = `${endpoints.pbench_server}/graphql`;
+  return request.post(endpoint, {
     data: {
       query: `
         query($id: ID!) {
@@ -23,7 +24,7 @@ export async function getSession(params) {
 
 // queries all the available shared sessions from the database to display
 export async function getAllSessions() {
-  const endpoint = `${endpoints.graphql}`;
+  const endpoint = `${endpoints.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {
@@ -42,7 +43,8 @@ export async function getAllSessions() {
 
 export async function saveSession(params) {
   const { sessionConfig, description } = params;
-  return request.post(endpoints.graphql, {
+  const endpoint = `${endpoints.pbench_server}/graphql`;
+  return request.post(endpoint, {
     data: {
       query: `
             mutation($config: String!, $description: String!) {
@@ -65,7 +67,7 @@ export async function saveSession(params) {
 export async function updateSessionDescription(params) {
   const { sessionId, description } = params;
 
-  const endpoint = `${endpoints.graphql}`;
+  const endpoint = `${endpoints.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {
@@ -92,7 +94,7 @@ export async function updateSessionDescription(params) {
 export async function deleteSession(params) {
   const { sessionId } = params;
 
-  const endpoint = `${endpoints.graphql}`;
+  const endpoint = `${endpoints.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {


### PR DESCRIPTION
This is a followup improvement PR on top of https://github.com/distributed-system-analysis/pbench-dashboard/pull/75

> Replaced all Elasticsearch calls to use pbench server APIs
Server address {pbench_server) needs to be specified in datastoreConfig.js to enable API calls
References for Elasticsearch and GraphQL from datastoreConfig.js have been moved to the server(pbench-server.cfg)