### PR TITLE
show timestamp in the results page

### DIFF
--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -187,7 +187,7 @@ class Results extends Component {
         dataIndex: 'run.end',
         key: 'run.end',
         render: val => (
-          <Tooltip title={val}>
+          <Tooltip content={val}>
             <span>{getDiffDate(val)}</span>
           </Tooltip>
         ),


### PR DESCRIPTION
Very minor fix for #101.