### PR TITLE
prevent form from reloading the page after each search query

### DIFF
--- a/src/e2e/search.e2e.js
+++ b/src/e2e/search.e2e.js
@@ -131,7 +131,7 @@ describe('search page component', () => {
 
   test('should execute search query', async () => {
     await page.waitForSelector(
-      '#root > div > main > section.pf-c-page__main-section.pf-m-light > div > div.pf-c-input-group > button',
+      '#root > div > main > section.pf-c-page__main-section.pf-m-light > div > div.pf-c-input-group > button > svg',
       { visible: true }
     );
     await page.click(

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -294,7 +294,12 @@ class SearchList extends Component {
                     type="primary"
                     name="Filter"
                     disabled={updateFiltersDisabled}
-                    onClick={this.fetchSearchQuery}
+                    onClick={e => {
+                      // prevent form submit
+                      // from reloading the page.
+                      e.preventDefault();
+                      this.fetchSearchQuery();
+                    }}
                   />
                   <Button
                     type="secondary"


### PR DESCRIPTION
The search page form was resetting, making the page reload each time we made a search query, which triggered network requests to aliases and mappings again in a never ending cycle, due to which we were never able to fetch the query results, which is fixed now. This PR fixes issue #103