### PR TITLE
Reference API endpoints via environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ _roadhog-api-doc
 .DS_Store
 npm-debug.log*
 yarn-error.log
-/mock/datastoreConfig.js
 
 /coverage
 .idea
@@ -30,3 +29,6 @@ package-lock.json
 
 # jest tests
 __snapshots__
+
+# config
+/config/endpoints.js

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Pbench Dashboard is a web-based platform for consuming indexed performance bench
 ├── public
 │   └── favicon.ico                 # favicon
 ├── mock
-│   └── datastoreConfig.js.example  # datastore configuration
+│   ├── api.js                      # mocked api
+│   └── user.js                     # mocked user api
 ├── config
 │   ├── config.js                   # webpack configuration
-│   └── router.config.js            # webpack routing configuration
+│   ├── router.config.js            # webpack routing configuration
+│   └── endpoints.js                # api endpoint configuration
 ├── src
 │   ├── assets                      # local static files
 │   ├── common                      # common configurations (navigation, menu, etc.)
@@ -66,20 +68,18 @@ This will automatically open the application on [http://localhost:8000](http://l
 
 ## Local Development
 
-Both the production and development builds of the dashboard require specific configurations in order to run on their respective environment.
+Both the production and development builds of the dashboard require API endpoint configurations in order to query data from specific datastores.
 
-Copy the `datastoreConfig.js.example` file in the `mock/` directory to `datastoreConfig.js` and modify the configuration fields within the route definition. Please reference the following example for required configuration fields.
+`endpoints.js` in the `config/` directory contains references to datastores required to visualize data in the dashboard. Please reference the following example for required configuration fields.
 
 ```JavaScript
 export default {
-  '/dev/datastoreConfig': {
-      "elasticsearch": "http://elasticsearch.example.com",
-      "results": "http://results.example.com",
-      "graphql": "http://graphql.example.com",
-      "prefix": "example.prefix",
-      "run_index": "example.index",
-      "result_index": "example.index"
-  },
+  "elasticsearch": "http://elasticsearch.example.com",
+  "results": "http://results.example.com",
+  "graphql": "http://graphql.example.com",
+  "prefix": "example.prefix",
+  "run_index": "example.index",
+  "result_index": "example.index"
 }
 ```
 

--- a/config/config.js
+++ b/config/config.js
@@ -1,8 +1,9 @@
 import pageRoutes from './router.config';
+import endpoints from './endpoints';
 
 export default {
   define: {
-    'process.env': process.env.NODE_ENV,
+    'process.env.endpoints': endpoints,
   },
   dynamicImport: undefined,
   base: '/dashboard/',

--- a/config/endpoints.js
+++ b/config/endpoints.js
@@ -1,0 +1,8 @@
+export default {
+  elasticsearch: 'http://test_domain.com',
+  results: 'http://test_domain.com',
+  graphql: 'http://test_domain.com',
+  prefix: 'test_prefix.',
+  result_index: 'test_index.',
+  run_index: 'test_index.',
+};

--- a/e2etests
+++ b/e2etests
@@ -5,18 +5,6 @@
 # directory.
 cd $(dirname ${0})
 
-# Setup the mock'd data store configuration.
-cat > mock/datastoreConfig.js <<EOF
-export default {
-  '/dev/datastoreConfig': {
-    elasticsearch: 'http://test_domain.com',
-    results: 'http://test_domain.com',
-    graphql: 'http://test_domain.com',
-    prefix: 'test_prefix.',
-    run_index: 'test_index.',
-  },
-};
-EOF
 # Make sure the yarn environment is all up-to-date, or perform the
 # install ahead of actually running the tests.
 printf -- "Running \"yarn install\" command ...\n" 

--- a/mock/api.js
+++ b/mock/api.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
-import config from './datastoreConfig';
+import endpoints from '../config/endpoints';
 import constants from '../config/constants';
 
 // Generate controllers as per max page size options
@@ -22,8 +22,7 @@ export const generateMockControllerAggregation = {
   },
 };
 
-const datastoreConfig = config['/dev/datastoreConfig'];
-const prefix = datastoreConfig.prefix + datastoreConfig.run_index.slice(0, -1);
+const prefix = endpoints.prefix + endpoints.run_index.slice(0, -1);
 export const mockIndices = {
   [`${prefix}.2019-08-01`]: {},
   [`${prefix}.2019-09-01`]: {},

--- a/mock/datastoreConfig.js.example
+++ b/mock/datastoreConfig.js.example
@@ -1,9 +1,0 @@
-export default {
-  '/dev/datastoreConfig': {
-      "elasticsearch": "",
-      "results": "",
-      "graphql": "",
-      "prefix": "",
-      "run_index": "",
-  },
-}

--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -73,7 +73,6 @@ class GlobalHeader extends Component {
 
   render() {
     const {
-      datastoreConfig,
       savingSession,
       sessionBannerVisible,
       sessionDescription,
@@ -102,12 +101,7 @@ class GlobalHeader extends Component {
             banner
           />
         )}
-        <SessionModal
-          datastoreConfig={datastoreConfig}
-          savingSession={savingSession}
-          sessionConfig={store}
-          dispatch={dispatch}
-        />
+        <SessionModal savingSession={savingSession} sessionConfig={store} dispatch={dispatch} />
         <PageHeaderToolsGroup>
           <PageHeaderToolsItem>
             <Button

--- a/src/components/SessionModal/index.js
+++ b/src/components/SessionModal/index.js
@@ -48,7 +48,7 @@ class SessionModal extends Component {
   };
 
   onGenerate = () => {
-    const { dispatch, datastoreConfig } = this.props;
+    const { dispatch } = this.props;
     let { sessionConfig } = this.props;
     const { description } = this.state;
     sessionConfig = JSON.stringify(sessionConfig);
@@ -58,7 +58,6 @@ class SessionModal extends Component {
       payload: {
         sessionConfig,
         description,
-        datastoreConfig,
       },
     }).then(result => {
       this.setState({

--- a/src/layouts/BasicLayout.js
+++ b/src/layouts/BasicLayout.js
@@ -44,8 +44,7 @@ const getBreadcrumbNameMap = memoizeOne(menu => {
   return routerMap;
 }, deepEqual);
 
-@connect(({ global, datastore, loading, auth }) => ({
-  datastoreConfig: datastore.datastoreConfig,
+@connect(({ global, loading, auth }) => ({
   sessionBannerVisible: global.sessionBannerVisible,
   sessionDescription: global.sessionDescription,
   sessionId: global.sessionId,
@@ -94,7 +93,6 @@ class BasicLayout extends React.PureComponent {
 
   render() {
     const {
-      datastoreConfig,
       savingSession,
       sessionBannerVisible,
       sessionDescription,
@@ -110,7 +108,6 @@ class BasicLayout extends React.PureComponent {
           <Page
             header={
               <GlobalHeader
-                datastoreConfig={datastoreConfig}
                 savingSession={savingSession}
                 sessionBannerVisible={sessionBannerVisible}
                 sessionDescription={sessionDescription}

--- a/src/models/datastore.js
+++ b/src/models/datastore.js
@@ -1,34 +1,20 @@
 import getDefaultDateRange from '../utils/moment_constants';
-import { queryDatastoreConfig, queryMonthIndices } from '../services/datastore';
+import queryMonthIndices from '../services/datastore';
 
 export default {
   namespace: 'datastore',
 
   state: {
-    datastoreConfig: {},
     indices: [],
   },
 
   effects: {
-    *fetchDatastoreConfig({ payload }, { call, put }) {
-      const response = yield call(queryDatastoreConfig, payload);
-
-      // Remove the trailing slashes if present, we'll take care of adding
-      // them back in the proper context.
-      response.elasticsearch = response.elasticsearch.replace(/\/+$/, '');
-      response.results = response.results.replace(/\/+$/, '');
-
-      yield put({
-        type: 'getDatastoreConfig',
-        payload: response,
-      });
-    },
     *fetchMonthIndices({ payload }, { call, put }) {
       const response = yield call(queryMonthIndices, payload);
-      const { datastoreConfig } = payload;
+      const { endpoints } = process.env;
       const indices = [];
 
-      const prefix = datastoreConfig.prefix + datastoreConfig.run_index.slice(0, -1);
+      const prefix = endpoints.prefix + endpoints.run_index.slice(0, -1);
       Object.keys(response).forEach(index => {
         if (index.includes(prefix)) {
           indices.push(index.split('.').pop());
@@ -49,12 +35,6 @@ export default {
   },
 
   reducers: {
-    getDatastoreConfig(state, { payload }) {
-      return {
-        ...state,
-        datastoreConfig: payload,
-      };
-    },
     getMonthIndices(state, { payload }) {
       return {
         ...state,

--- a/src/models/search.js
+++ b/src/models/search.js
@@ -19,9 +19,10 @@ export default {
     },
     *fetchIndexMapping({ payload }, { call, put }) {
       const response = yield call(queryIndexMapping, payload);
-      const { datastoreConfig, indices } = payload;
+      const { indices } = payload;
+      const { endpoints } = process.env;
 
-      const index = datastoreConfig.prefix + datastoreConfig.run_index + indices[0];
+      const index = endpoints.prefix + endpoints.run_index + indices[0];
       const mapping = response[index].mappings['pbench-run'].properties;
       const fields = [];
       const filters = {};

--- a/src/pages/ComparisonSelect/index.js
+++ b/src/pages/ComparisonSelect/index.js
@@ -23,12 +23,11 @@ import Button from '@/components/Button';
 import Table from '@/components/Table';
 import { filterIterations } from '../../utils/parse';
 
-@connect(({ datastore, global, dashboard, loading }) => ({
+@connect(({ global, dashboard, loading }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
   results: dashboard.results,
   controllers: dashboard.controllers,
-  datastoreConfig: datastore.datastoreConfig,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedDateRange: global.selectedDateRange,
@@ -47,11 +46,11 @@ class ComparisonSelect extends React.Component {
   }
 
   componentDidMount() {
-    const { selectedResults, selectedDateRange, datastoreConfig, dispatch } = this.props;
+    const { selectedResults, selectedDateRange, dispatch } = this.props;
 
     dispatch({
       type: 'dashboard/fetchIterationSamples',
-      payload: { selectedResults, selectedDateRange, datastoreConfig },
+      payload: { selectedResults, selectedDateRange },
     });
   }
 

--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -25,12 +25,9 @@ const { TabPane } = Tabs;
   controllers: dashboard.controllers,
   indices: datastore.indices,
   selectedDateRange: global.selectedDateRange,
-  datastoreConfig: datastore.datastoreConfig,
   favoriteControllers: user.favoriteControllers,
   loadingControllers:
-    loading.effects['dashboard/fetchControllers'] ||
-    loading.effects['datastore/fetchMonthIndices'] ||
-    loading.effects['datastore/fetchDatastoreConfig'],
+    loading.effects['dashboard/fetchControllers'] || loading.effects['datastore/fetchMonthIndices'],
 }))
 class Controllers extends Component {
   constructor(props) {
@@ -51,7 +48,7 @@ class Controllers extends Component {
       selectedDateRange.start === '' ||
       selectedDateRange.end === ''
     ) {
-      this.queryDatastoreConfig();
+      this.fetchMonthIndices();
     }
   }
 
@@ -63,32 +60,21 @@ class Controllers extends Component {
     }
   }
 
-  queryDatastoreConfig = async () => {
+  fetchMonthIndices = async () => {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'datastore/fetchDatastoreConfig',
-    }).then(() => {
-      this.fetchMonthIndices();
-    });
-  };
-
-  fetchMonthIndices = async () => {
-    const { dispatch, datastoreConfig } = this.props;
-
-    dispatch({
       type: 'datastore/fetchMonthIndices',
-      payload: { datastoreConfig },
     }).then(() => {
       this.fetchControllers();
     });
   };
 
   fetchControllers = () => {
-    const { dispatch, datastoreConfig, selectedDateRange } = this.props;
+    const { dispatch, selectedDateRange } = this.props;
     dispatch({
       type: 'dashboard/fetchControllers',
-      payload: { datastoreConfig, selectedDateRange },
+      payload: { selectedDateRange },
     });
   };
 

--- a/src/pages/Explore/index.js
+++ b/src/pages/Explore/index.js
@@ -18,9 +18,8 @@ import Table from '@/components/Table';
 
 const { TextArea } = Input;
 
-@connect(({ datastore, explore, loading }) => ({
+@connect(({ explore, loading }) => ({
   sharedSessions: explore.sharedSessions,
-  datastoreConfig: datastore.datastoreConfig,
   loadingSharedSessions: loading.effects['explore/fetchSharedSessions'],
 }))
 class Explore extends Component {
@@ -36,7 +35,7 @@ class Explore extends Component {
   }
 
   componentDidMount() {
-    this.fetchDatastoreConfig();
+    this.fetchSharedSessions();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -47,22 +46,11 @@ class Explore extends Component {
     }
   }
 
-  fetchDatastoreConfig = () => {
+  fetchSharedSessions = () => {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'datastore/fetchDatastoreConfig',
-    }).then(() => {
-      this.fetchSharedSessions();
-    });
-  };
-
-  fetchSharedSessions = () => {
-    const { dispatch, datastoreConfig } = this.props;
-
-    dispatch({
       type: 'explore/fetchSharedSessions',
-      payload: { datastoreConfig },
     });
   };
 
@@ -73,10 +61,10 @@ class Explore extends Component {
   };
 
   editDescription = (id, value) => {
-    const { dispatch, datastoreConfig } = this.props;
+    const { dispatch } = this.props;
     dispatch({
       type: 'explore/editDescription',
-      payload: { datastoreConfig, id, value },
+      payload: { id, value },
     }).then(() => {
       this.fetchSharedSessions();
     });
@@ -110,11 +98,11 @@ class Explore extends Component {
   };
 
   deleteSharedSession = record => {
-    const { dispatch, datastoreConfig } = this.props;
+    const { dispatch } = this.props;
     const { id } = record;
     dispatch({
       type: 'explore/deleteSharedSessions',
-      payload: { datastoreConfig, id },
+      payload: { id },
     }).then(() => {
       this.fetchSharedSessions();
     });

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -20,13 +20,12 @@ import { getDiffDate } from '@/utils/moment_constants';
 
 const { TabPane } = Tabs;
 
-@connect(({ datastore, global, dashboard, loading, user }) => ({
+@connect(({ global, dashboard, loading, user }) => ({
   selectedDateRange: global.selectedDateRange,
   results: dashboard.results[global.selectedControllers[0]]
     ? dashboard.results[global.selectedControllers[0]]
     : [],
   selectedControllers: global.selectedControllers,
-  datastoreConfig: datastore.datastoreConfig,
   favoriteResults: user.favoriteResults,
   loading: loading.effects['dashboard/fetchResults'],
 }))
@@ -41,19 +40,12 @@ class Results extends Component {
   }
 
   componentDidMount() {
-    const {
-      dispatch,
-      results,
-      datastoreConfig,
-      selectedDateRange,
-      selectedControllers,
-    } = this.props;
+    const { dispatch, results, selectedDateRange, selectedControllers } = this.props;
 
     if (results.length === 0) {
       dispatch({
         type: 'dashboard/fetchResults',
         payload: {
-          datastoreConfig,
           selectedDateRange,
           controller: selectedControllers,
         },

--- a/src/pages/RunComparison/index.js
+++ b/src/pages/RunComparison/index.js
@@ -26,13 +26,12 @@ import {
 import TimeseriesGraph from '@/components/TimeseriesGraph';
 import { generateClusters } from '../../utils/parse';
 
-@connect(({ dashboard, global, datastore }) => ({
+@connect(({ dashboard, global }) => ({
   iterationParams: dashboard.iterationParams,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedDateRange: global.selectedDateRange,
   selectedIterations: global.selectedIterations,
-  datastoreConfig: datastore.datastoreConfig,
 }))
 class RunComparison extends React.Component {
   constructor(props) {
@@ -46,13 +45,7 @@ class RunComparison extends React.Component {
   }
 
   componentDidMount() {
-    const {
-      iterationParams,
-      selectedIterations,
-      selectedDateRange,
-      datastoreConfig,
-      dispatch,
-    } = this.props;
+    const { iterationParams, selectedIterations, selectedDateRange, dispatch } = this.props;
 
     this.setState({ loadingClusters: true });
     const clusters = generateClusters(selectedIterations, iterationParams);
@@ -60,7 +53,7 @@ class RunComparison extends React.Component {
 
     dispatch({
       type: 'dashboard/fetchTimeseriesData',
-      payload: { selectedIterations, selectedDateRange, clusters, datastoreConfig },
+      payload: { selectedDateRange, selectedIterations, clusters },
     }).then(timeseriesClusters => {
       this.setState({
         clusters: timeseriesClusters,

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -29,7 +29,6 @@ import AntdDatePicker from '@/components/DatePicker';
   selectedDateRange: global.selectedDateRange,
   selectedResults: global.selectedResults,
   indices: datastore.indices,
-  datastoreConfig: datastore.datastoreConfig,
   loadingMapping: loading.effects['search/fetchIndexMapping'],
   loadingSearchResults: loading.effects['search/fetchSearchResults'],
 }))
@@ -53,7 +52,7 @@ class SearchList extends Component {
       selectedDateRange.start === '' ||
       selectedDateRange.end === ''
     ) {
-      this.queryDatastoreConfig();
+      this.fetchMonthIndices();
     }
   }
 
@@ -71,34 +70,22 @@ class SearchList extends Component {
     }
   }
 
-  queryDatastoreConfig = async () => {
+  fetchMonthIndices = async () => {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'datastore/fetchDatastoreConfig',
-    }).then(() => {
-      this.fetchMonthIndices();
-    });
-  };
-
-  fetchMonthIndices = async () => {
-    const { dispatch, datastoreConfig } = this.props;
-
-    dispatch({
       type: 'datastore/fetchMonthIndices',
-      payload: { datastoreConfig },
     }).then(() => {
       this.fetchIndexMapping();
     });
   };
 
   fetchIndexMapping = () => {
-    const { dispatch, datastoreConfig, indices } = this.props;
+    const { dispatch, indices } = this.props;
 
     dispatch({
       type: 'search/fetchIndexMapping',
       payload: {
-        datastoreConfig,
         indices,
       },
     });
@@ -178,13 +165,12 @@ class SearchList extends Component {
 
   fetchSearchQuery = () => {
     const { searchQuery } = this.state;
-    const { dispatch, datastoreConfig, selectedFields, selectedDateRange } = this.props;
+    const { dispatch, selectedFields, selectedDateRange } = this.props;
 
     this.commitRunSelections().then(() => {
       dispatch({
         type: 'search/fetchSearchResults',
         payload: {
-          datastoreConfig,
           selectedDateRange,
           selectedFields,
           query: searchQuery,

--- a/src/pages/SessionPlaceholder/index.js
+++ b/src/pages/SessionPlaceholder/index.js
@@ -4,22 +4,11 @@ import { routerRedux } from 'dva/router';
 import { Spin } from 'antd';
 
 @connect(store => ({
-  datastoreConfig: store.datastore.datastoreConfig,
   store,
 }))
 class SessionPlaceholder extends React.Component {
   componentDidMount = () => {
-    this.queryDatastoreConfig();
-  };
-
-  queryDatastoreConfig = async () => {
-    const { dispatch } = this.props;
-
-    dispatch({
-      type: 'datastore/fetchDatastoreConfig',
-    }).then(() => {
-      this.persistCurrentSession();
-    });
+    this.persistCurrentSession();
   };
 
   persistCurrentSession = () => {
@@ -34,7 +23,7 @@ class SessionPlaceholder extends React.Component {
   };
 
   queryUserSession = async () => {
-    const { dispatch, datastoreConfig } = this.props;
+    const { dispatch } = this.props;
     const path = window.location.href;
     const id = path.substring(path.lastIndexOf('/') + 1);
 
@@ -42,7 +31,6 @@ class SessionPlaceholder extends React.Component {
       type: 'global/fetchUserSession',
       payload: {
         id,
-        datastoreConfig,
       },
     }).then(response => {
       this.rehydrateNamespaces(response.sessionConfig, response.sessionMetadata);

--- a/src/pages/Summary/index.js
+++ b/src/pages/Summary/index.js
@@ -41,12 +41,11 @@ const tocColumns = [
   },
 ];
 
-@connect(({ global, datastore, dashboard, loading }) => ({
+@connect(({ global, dashboard, loading }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
   result: dashboard.result,
   tocResult: dashboard.tocResult,
-  datastoreConfig: datastore.datastoreConfig,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedDateRange: global.selectedDateRange,
@@ -67,16 +66,15 @@ class Summary extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, datastoreConfig, selectedDateRange, selectedResults } = this.props;
+    const { dispatch, selectedDateRange, selectedResults } = this.props;
 
     dispatch({
       type: 'dashboard/fetchIterationSamples',
-      payload: { selectedResults, selectedDateRange, datastoreConfig },
+      payload: { selectedResults, selectedDateRange },
     });
     dispatch({
       type: 'dashboard/fetchResult',
       payload: {
-        datastoreConfig,
         selectedDateRange,
         result: selectedResults[0]['run.name'],
       },
@@ -84,7 +82,6 @@ class Summary extends React.Component {
     dispatch({
       type: 'dashboard/fetchTocResult',
       payload: {
-        datastoreConfig,
         selectedDateRange,
         id: selectedResults[0].id,
       },

--- a/src/services/datastore.js
+++ b/src/services/datastore.js
@@ -1,35 +1,9 @@
 import request from '../utils/request';
 
-/**
- * This service references the node environment for retrieval of
- * the API config file. Node specifies two types of environments
- * depending on how the dashboard has been run:
- *
- * `development` - the dashboard is referencing `dev.config.json`
- * and has been executed from the root directory using the `start`
- * script.
- *
- * `production` - the dashboard has been bundled to minimized
- * js, css, and html files using the `build` script and is
- * deployed on a web server.
- */
-export async function queryDatastoreConfig() {
-  let configEndpoint = '';
-  const environment = process.env || 'development';
+const { endpoints } = process.env;
 
-  if (environment === 'development') {
-    configEndpoint = '/dev/datastoreConfig';
-  } else {
-    configEndpoint = '/dashboard/config.json';
-  }
-
-  return request.get(configEndpoint);
-}
-
-export async function queryMonthIndices(params) {
-  const { datastoreConfig } = params;
-
-  const endpoint = `${datastoreConfig.elasticsearch}/_aliases`;
+export default async function queryMonthIndices() {
+  const endpoint = `${endpoints.elasticsearch}/_aliases`;
 
   return request.get(endpoint);
 }

--- a/src/services/explore.js
+++ b/src/services/explore.js
@@ -1,10 +1,10 @@
 import request from '../utils/request';
 
-// queries all the available shared sessions from the database to display
-export async function querySharedSessions(params) {
-  const { datastoreConfig } = params;
+const { endpoints } = process.env;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+// queries all the available shared sessions from the database to display
+export async function querySharedSessions() {
+  const endpoint = `${endpoints.graphql}`;
 
   return request.post(endpoint, {
     data: {
@@ -23,9 +23,9 @@ export async function querySharedSessions(params) {
 
 // Updates the description of shared session, provided by the user in the database.
 export async function updateDescription(params) {
-  const { datastoreConfig, id, value } = params;
+  const { id, value } = params;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+  const endpoint = `${endpoints.graphql}`;
 
   return request.post(endpoint, {
     data: {
@@ -50,9 +50,9 @@ export async function updateDescription(params) {
 
 // Deletes a shared session.
 export async function deleteSharedSessions(params) {
-  const { datastoreConfig, id } = params;
+  const { id } = params;
 
-  const endpoint = `${datastoreConfig.graphql}`;
+  const endpoint = `${endpoints.graphql}`;
 
   return request.post(endpoint, {
     data: {

--- a/src/services/global.js
+++ b/src/services/global.js
@@ -1,8 +1,10 @@
 import request from '../utils/request';
 
+const { endpoints } = process.env;
+
 export async function saveUserSession(params) {
-  const { sessionConfig, description, datastoreConfig } = params;
-  return request.post(datastoreConfig.graphql, {
+  const { sessionConfig, description } = params;
+  return request.post(endpoints.graphql, {
     data: {
       query: `
             mutation($config: String!, $description: String!) {
@@ -22,8 +24,8 @@ export async function saveUserSession(params) {
 }
 
 export async function queryUserSession(params) {
-  const { id, datastoreConfig } = params;
-  return request.post(datastoreConfig.graphql, {
+  const { id } = params;
+  return request.post(endpoints.graphql, {
     data: {
       query: `
         query($id: ID!) {

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -1,23 +1,24 @@
 import { getAllMonthsWithinRange } from '../utils/moment_constants';
 import request from '../utils/request';
 
+const { endpoints } = process.env;
+
 export async function queryIndexMapping(params) {
-  const { datastoreConfig, indices } = params;
+  const { indices } = params;
 
-  const endpoint = `${datastoreConfig.elasticsearch}/${datastoreConfig.prefix}${
-    datastoreConfig.run_index
-  }${indices[0]}/_mappings`;
-
+  const endpoint = `${endpoints.elasticsearch}/${endpoints.prefix}${endpoints.run_index}${
+    indices[0]
+  }/_mappings`;
   return request.get(endpoint);
 }
 
 export async function searchQuery(params) {
   try {
-    const { datastoreConfig, selectedFields, selectedDateRange, query } = params;
+    const { selectedFields, selectedDateRange, query } = params;
 
-    const endpoint = `${datastoreConfig.elasticsearch}/${getAllMonthsWithinRange(
-      datastoreConfig,
-      datastoreConfig.run_index,
+    const endpoint = `${endpoints.elasticsearch}/${getAllMonthsWithinRange(
+      endpoints,
+      endpoints.run_index,
       selectedDateRange
     )}/_search`;
 

--- a/src/utils/moment_constants.js
+++ b/src/utils/moment_constants.js
@@ -12,7 +12,7 @@ export default function getDefaultDateRange(lastIndex) {
 }
 
 // Gets all months within a specified date range
-export function getAllMonthsWithinRange(datastoreConfig, index, selectedDateRange) {
+export function getAllMonthsWithinRange(endpoints, index, selectedDateRange) {
   const startDate = moment(selectedDateRange.start);
   const endDate = moment(selectedDateRange.end);
   const referenceDate = startDate.clone();
@@ -28,10 +28,10 @@ export function getAllMonthsWithinRange(datastoreConfig, index, selectedDateRang
     monthResults.push(referenceDate.format('YYYY-MM'));
   }
   monthResults.forEach(monthValue => {
-    if (index === datastoreConfig.result_index) {
-      queryString += `${datastoreConfig.prefix + index + monthValue}-*,`;
+    if (index === endpoints.result_index) {
+      queryString += `${endpoints.prefix + index + monthValue}-*,`;
     } else {
-      queryString += `${datastoreConfig.prefix + index + monthValue},`;
+      queryString += `${endpoints.prefix + index + monthValue},`;
     }
   });
   return queryString;

--- a/unittests
+++ b/unittests
@@ -2,18 +2,6 @@
 
 cd $(dirname ${0})
 
-# Setup the mock'd data store configuration.
-cat > mock/datastoreConfig.js <<EOF
-export default {
-  '/dev/datastoreConfig': {
-    elasticsearch: 'http://test_domain.com',
-    results: 'http://test_domain.com',
-    graphql: 'http://test_domain.com',
-    prefix: 'test_prefix.',
-    run_index: 'test_index.',
-  },
-};
-EOF
 yarn install --network-timeout 1000000
 if [[ ${?} -ne 0 ]]; then
   echo "yarn install failed!" >&2


### PR DESCRIPTION
This PR aims to relocate the `datastoreConfig.js` config file to `config/endpoints.js` and dynamically load with the umi config to expose environment variables globally once the Node.js process boots up.

This migration removes the need to query the endpoint config file within the page component mounts for each component referenced as a "base" route in the dashboard. This removes a layer of abstraction as API endpoints are now only referenced in the `services` directory for queries originating from the respective component. 

In order to support initialization of a Sentry instance at the earliest entrypoint of the dashboard codebase, a reference to the Sentry endpoint url needs to be made available directly after the Node.js process boots in order to optimize the scope of information available to collect at dashboard initialization. 

In addition, this change makes the transition to the singular pbench server API as simple as modifying `endpoint.js` and removing post processing where necessary.