### PR TITLE
favorite records for registered users

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -25,9 +25,21 @@ export default {
         payload,
       });
     },
+    *removeControllerFromFavorites({ payload }, { put }) {
+      yield put({
+        type: 'removeFavoriteController',
+        payload,
+      });
+    },
     *favoriteResult({ payload }, { put }) {
       yield put({
         type: 'modifyFavoritedResults',
+        payload,
+      });
+    },
+    *removeResultFromFavorites({ payload }, { put }) {
+      yield put({
+        type: 'removeFavoriteResult',
         payload,
       });
     },
@@ -56,6 +68,18 @@ export default {
       return {
         ...state,
         favoriteResults: [...state.favoriteResults, payload],
+      };
+    },
+    removeFavoriteController(state, { payload }) {
+      return {
+        ...state,
+        favoriteControllers: state.favoriteControllers.filter(item => item.key !== payload.key),
+      };
+    },
+    removeFavoriteResult(state, { payload }) {
+      return {
+        ...state,
+        favoriteResults: state.favoriteResults.filter(item => item.key !== payload.key),
       };
     },
   },

--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -142,6 +142,17 @@ class Controllers extends Component {
     });
   };
 
+  removeControllerFromFavorites = (event, value, controller) => {
+    // Stop propagation from going to the next page
+    event.stopPropagation();
+    const { dispatch } = this.props;
+    // dispatch an action to favorite controller
+    dispatch({
+      type: 'user/removeControllerFromFavorites',
+      payload: controller,
+    });
+  };
+
   render() {
     const { controllers } = this.state;
     const { loadingControllers, favoriteControllers, auth } = this.props;
@@ -184,7 +195,11 @@ class Controllers extends Component {
             }
           });
           if (isFavorite) {
-            return <Icon type="star" theme="filled" />;
+            return (
+              <a onClick={e => this.removeControllerFromFavorites(e, null, row)}>
+                <Icon type="star" theme="filled" />
+              </a>
+            );
           }
           return (
             <a onClick={e => this.favoriteRecord(e, null, row)}>

--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -18,14 +18,17 @@ import SearchBar from '@/components/SearchBar';
 import AntdDatePicker from '@/components/DatePicker';
 import Table from '@/components/Table';
 import { getDiffDate } from '@/utils/moment_constants';
+import { isLoggedInUser } from '@/utils/utils';
+import styles from './index.less';
 
 const { TabPane } = Tabs;
 
-@connect(({ datastore, global, dashboard, loading, user }) => ({
+@connect(({ datastore, global, dashboard, loading, user, auth }) => ({
   controllers: dashboard.controllers,
   indices: datastore.indices,
   selectedDateRange: global.selectedDateRange,
   favoriteControllers: user.favoriteControllers,
+  auth: auth.auth,
   loadingControllers:
     loading.effects['dashboard/fetchControllers'] || loading.effects['datastore/fetchMonthIndices'],
 }))
@@ -141,7 +144,7 @@ class Controllers extends Component {
 
   render() {
     const { controllers } = this.state;
-    const { loadingControllers, favoriteControllers } = this.props;
+    const { loadingControllers, favoriteControllers, auth } = this.props;
     const columns = [
       {
         title: 'Controller',
@@ -170,6 +173,7 @@ class Controllers extends Component {
         title: 'Actions',
         dataIndex: 'actions',
         key: 'actions',
+        className: isLoggedInUser(auth) ? null : styles.hide,
         render: (value, row) => {
           // if already favorited return a filled star,
           // else allow user to favorite a record

--- a/src/pages/Controllers/index.less
+++ b/src/pages/Controllers/index.less
@@ -1,0 +1,3 @@
+.hide {
+  display: none;
+}

--- a/src/pages/Controllers/index.test.js
+++ b/src/pages/Controllers/index.test.js
@@ -10,6 +10,7 @@ import AntdDatePicker from '@/components/DatePicker';
 const mockProps = {
   controllers: [],
   indices: [],
+  auth: { username: '' },
 };
 
 const mockDispatch = jest.fn();

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -146,6 +146,17 @@ class Results extends Component {
     });
   };
 
+  removeResultFromFavorites = (event, value, record) => {
+    // Stop propagation from going to the next page
+    event.stopPropagation();
+    const { dispatch } = this.props;
+    // dispatch an action to favorite controller
+    dispatch({
+      type: 'user/removeResultFromFavorites',
+      payload: record,
+    });
+  };
+
   render() {
     const { results, selectedRows } = this.state;
     const { selectedControllers, loading, favoriteResults, auth } = this.props;
@@ -201,7 +212,11 @@ class Results extends Component {
             }
           });
           if (isFavorite) {
-            return <Icon type="star" theme="filled" />;
+            return (
+              <a onClick={e => this.removeResultFromFavorites(e, null, row)}>
+                <Icon type="star" theme="filled" />
+              </a>
+            );
           }
           return (
             <a onClick={e => this.favoriteRecord(e, null, row)}>

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -17,14 +17,17 @@ import SearchBar from '@/components/SearchBar';
 import RowSelection from '@/components/RowSelection';
 import Table from '@/components/Table';
 import { getDiffDate } from '@/utils/moment_constants';
+import { isLoggedInUser } from '@/utils/utils';
+import styles from './index.less';
 
 const { TabPane } = Tabs;
 
-@connect(({ global, dashboard, loading, user }) => ({
+@connect(({ global, dashboard, loading, user, auth }) => ({
   selectedDateRange: global.selectedDateRange,
   results: dashboard.results[global.selectedControllers[0]]
     ? dashboard.results[global.selectedControllers[0]]
     : [],
+  auth: auth.auth,
   selectedControllers: global.selectedControllers,
   favoriteResults: user.favoriteResults,
   loading: loading.effects['dashboard/fetchResults'],
@@ -145,12 +148,11 @@ class Results extends Component {
 
   render() {
     const { results, selectedRows } = this.state;
-    const { selectedControllers, loading, favoriteResults } = this.props;
+    const { selectedControllers, loading, favoriteResults, auth } = this.props;
     const rowSelection = {
       // eslint-disable-next-line no-shadow
       onSelect: (record, selected, selectedRows) => this.onSelectChange(selectedRows),
     };
-
     const columns = [
       {
         title: 'Result',
@@ -187,6 +189,7 @@ class Results extends Component {
       {
         title: 'Actions',
         dataIndex: 'actions',
+        className: isLoggedInUser(auth) ? null : styles.hide,
         key: 'actions',
         render: (value, row) => {
           // if already favorited return a filled star,

--- a/src/pages/Results/index.less
+++ b/src/pages/Results/index.less
@@ -1,0 +1,3 @@
+.hide {
+  display: none;
+}

--- a/src/pages/Results/index.test.js
+++ b/src/pages/Results/index.test.js
@@ -8,6 +8,7 @@ import Results from './index';
 
 const mockProps = {
   selectedControllers: ['controller1'],
+  auth: { username: '' },
 };
 
 const mockDispatch = jest.fn();

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -97,3 +97,10 @@ export const insertTocTreeData = (tocResult, items = [], [head, ...tail]) => {
   }
   return items;
 };
+
+export const isLoggedInUser = authObject => {
+  if (authObject.username) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
This PR introduces the following changes
- Hide the "actions" column for non-registered users, preventing them to bookmark records.
- Only registered users should be able to bookmark records and remove them.
- Fixes #94
