### PR TITLE
Dashboard support for ES7 / Pbench server 0.71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ package-lock.json
 __snapshots__
 
 # config
-public/endpoints.js
+#public/endpoints.js

--- a/README.md
+++ b/README.md
@@ -70,16 +70,19 @@ This will automatically open the application on [http://localhost:8000](http://l
 
 Both the production and development builds of the dashboard require API endpoint configurations in order to query data from specific datastores.
 
-`public/endpoints.js` contains references to datastores required to visualize data in the dashboard. Please reference the following example for required configuration fields:
+`public/endpoints.js` contains references to datastores and metadata required to visualize data in the dashboard. Please reference the following example for required configuration fields:
 
 ```JavaScript
 window.endpoints = {
   elasticsearch: 'http://test_domain.com',
   results: 'http://test_domain.com',
   graphql: 'http://test_domain.com',
+  pbench_server: 'http://test_domain.com:8001/api/v1',
   prefix: 'test_prefix.',
-  result_index: 'test_index.',
-  run_index: 'test_index.'
+  result_index: 'v.result-data-sample.',
+  result_data_index: 'v.result-data.',
+  run_index: 'v.run-data.',
+  run_toc_index: 'v.run-toc.'
 };
 ```
 

--- a/mock/api.js
+++ b/mock/api.js
@@ -3,7 +3,10 @@ import constants from '../config/constants';
 // Mocked test index components
 const endpoints = {
   prefix: 'test_prefix.',
-  run_index: 'test_index.',
+  run_index: 'vn.run-data.',
+  run_toc_index: 'vn.run-toc.',
+  result_index: 'vn.result-data-sample.',
+  result_data_index: 'vn.result-data.',
 };
 
 // Generate controllers as per max page size options
@@ -13,48 +16,48 @@ generatedBuckets = generatedBuckets.map((val, index) => {
   const key = index + 1;
   return {
     key: `controller_${key}`,
-    doc_count: key,
-    runs_prev1: { value: null },
-    runs: { value: key, value_as_string: key.toString() },
+    controller: `controller_${key}`,
+    results: key,
+    last_modified_value: key,
+    last_modified_string: key.toString(),
   };
 });
-export const generateMockControllerAggregation = {
-  aggregations: {
-    controllers: {
-      buckets: generatedBuckets,
-    },
-  },
-};
+export const generateMockControllerAggregation = generatedBuckets;
 
 const prefix = endpoints.prefix + endpoints.run_index.slice(0, -1);
-export const mockIndices = {
-  [`${prefix}.2019-08-01`]: {},
-  [`${prefix}.2019-09-01`]: {},
-};
+export const mockIndices = ['2019-09', '2019-08'];
 
 export const mockResults = {
   hits: {
     hits: [
       {
-        fields: {
-          'run.name': ['a_test_run'],
-          '@metadata.controller_dir': ['test_run.test_domain.com'],
-          'run.start': ['1111-11-11T11:11:11+00:00'],
-          'run.id': ['1111'],
-          'run.end': ['1111-11-11T11:11:12+00:00'],
-          'run.controller': ['test_run.test_domain.com'],
-          'run.config': ['test_size_1'],
+        _source: {
+          run: {
+            name: 'a_test_run',
+            start: '1111-11-11T11:11:11+00:00',
+            id: '1111',
+            end: '1111-11-11T11:11:12+00:00',
+            controller: 'test_run.test_domain.com',
+            config: 'test_size_1',
+          },
+          '@metadata': {
+            controller_dir: 'test_run.test_domain.com',
+          },
         },
       },
       {
-        fields: {
-          'run.name': ['b_test_run'],
-          '@metadata.controller_dir': ['b_test_run.test_domain.com'],
-          'run.start': ['1111-11-11T11:11:13+00:00'],
-          'run.id': ['2222'],
-          'run.end': ['1111-11-11T11:11:14+00:00'],
-          'run.controller': ['b_test_run.test_domain.com'],
-          'run.config': ['test_size_2'],
+        _source: {
+          run: {
+            name: 'b_test_run',
+            start: '1111-11-11T11:11:13+00:00',
+            id: '2222',
+            end: '1111-11-11T11:11:14+00:00',
+            controller: 'b_test_run.test_domain.com',
+            config: 'test_size_2',
+          },
+          '@metadata': {
+            controller_dir: 'b_test_run.test_domain.com',
+          },
         },
       },
     ],
@@ -62,22 +65,20 @@ export const mockResults = {
 };
 
 export const mockMappings = {
-  [`${prefix}.2019-09-01`]: {
+  [`${prefix}.2019-09`]: {
     mappings: {
-      'pbench-run': {
-        properties: {
-          run: {
-            properties: {
-              config: { type: 'string', index: 'not_analyzed' },
-              name: { type: 'string', index: 'not_analyzed' },
-              script: { type: 'string', index: 'not_analyzed' },
-              user: { type: 'string', index: 'not_analyzed' },
-            },
+      properties: {
+        run: {
+          properties: {
+            config: { type: 'keyword' },
+            name: { type: 'keyword' },
+            script: { type: 'keyword' },
+            user: { type: 'keyword' },
           },
-          '@metadata': {
-            properties: {
-              controller_dir: { type: 'string', index: 'not_analyzed' },
-            },
+        },
+        '@metadata': {
+          properties: {
+            controller_dir: { type: 'keyword' },
           },
         },
       },
@@ -91,12 +92,14 @@ export const mockSearch = {
     hits: [
       {
         _id: '1111',
-        fields: {
-          'run.config': ['test-size-1'],
-          'run.name': ['test_run'],
-          'run.script': ['test_controller'],
-          'run.user': ['test_user'],
-          '@metadata.controller_dir': ['test_controller'],
+        _source: {
+          run: {
+            config: 'test-size-1',
+            name: 'test_run',
+            script: 'test_controller',
+            user: 'test_user',
+          },
+          '@metadata.controller_dir': 'test_controller',
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbench_dashboard",
-  "version": "2.2.1-0",
+  "version": "3.0.0-1",
   "description": "UI solution for scalable visualization of benchmark data.",
   "private": true,
   "scripts": {

--- a/public/endpoints.js
+++ b/public/endpoints.js
@@ -3,6 +3,9 @@ window.endpoints = {
   results: 'http://test_domain.com',
   graphql: 'http://test_domain.com',
   prefix: 'test_prefix.',
-  result_index: 'test_index.',
-  run_index: 'test_index.',
+  run_index: 'vn.run-data.',
+  run_toc_index: 'vn.run-toc.',
+  result_index: 'vn.result-data-sample.',
+  result_data_index: 'vn.result-data.',
+  pbench_server: 'http://test_domain.com/api/v1',
 };

--- a/src/e2e/controllers.e2e.js
+++ b/src/e2e/controllers.e2e.js
@@ -15,14 +15,14 @@ beforeAll(async () => {
   // Intercept network requests
   await page.setRequestInterception(true);
   page.on('request', request => {
-    if (request.method() === 'POST' && request.postData().includes('controllers')) {
+    if (request.method() === 'POST' && request.url().includes('/controllers/list')) {
       request.respond({
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(generateMockControllerAggregation),
       });
-    } else if (request.method() === 'GET' && request.url().includes('aliases')) {
+    } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({
         status: 200,
         contentType: 'application/json',

--- a/src/e2e/results.e2e.js
+++ b/src/e2e/results.e2e.js
@@ -15,14 +15,14 @@ beforeAll(async () => {
   // Intercept network requests
   await page.setRequestInterception(true);
   page.on('request', request => {
-    if (request.method() === 'POST' && request.postData().includes('controllers')) {
+    if (request.method() === 'POST' && request.url().includes('/controllers/list')) {
       request.respond({
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(generateMockControllerAggregation),
       });
-    } else if (request.method() === 'GET' && request.url().includes('aliases')) {
+    } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({
         status: 200,
         contentType: 'application/json',

--- a/src/e2e/search.e2e.js
+++ b/src/e2e/search.e2e.js
@@ -26,14 +26,14 @@ beforeAll(async () => {
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(mockSearch),
       });
-    } else if (request.method() === 'GET' && request.url().includes('aliases')) {
+    } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(mockIndices),
       });
-    } else if (request.method() === 'GET' && request.url().includes('mappings')) {
+    } else if (request.method() === 'GET' && request.url().includes('_mappings')) {
       request.respond({
         status: 200,
         contentType: 'application/json',

--- a/src/e2e/session.e2e.js
+++ b/src/e2e/session.e2e.js
@@ -15,14 +15,14 @@ beforeAll(async () => {
   // Intercept network requests
   await page.setRequestInterception(true);
   page.on('request', request => {
-    if (request.method() === 'POST' && request.postData().includes('controllers')) {
+    if (request.method() === 'POST' && request.url().includes('/controllers/list')) {
       request.respond({
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
         body: JSON.stringify(generateMockControllerAggregation),
       });
-    } else if (request.method() === 'GET' && request.url().includes('aliases')) {
+    } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({
         status: 200,
         contentType: 'application/json',

--- a/src/models/datastore.js
+++ b/src/models/datastore.js
@@ -11,25 +11,14 @@ export default {
   effects: {
     *fetchMonthIndices({ payload }, { call, put }) {
       const response = yield call(queryMonthIndices, payload);
-      const { endpoints } = window;
-      const indices = [];
-
-      const prefix = endpoints.prefix + endpoints.run_index.slice(0, -1);
-      Object.keys(response).forEach(index => {
-        if (index.includes(prefix)) {
-          indices.push(index.split('.').pop());
-        }
-      });
-
-      indices.sort((a, b) => parseInt(b.replace('-', ''), 10) - parseInt(a.replace('-', ''), 10));
 
       yield put({
         type: 'getMonthIndices',
-        payload: indices,
+        payload: response,
       });
       yield put({
         type: 'global/updateSelectedDateRange',
-        payload: getDefaultDateRange(indices[0]),
+        payload: getDefaultDateRange(response[0]),
       });
     },
   },

--- a/src/services/datastore.js
+++ b/src/services/datastore.js
@@ -3,7 +3,7 @@ import request from '../utils/request';
 const { endpoints } = window;
 
 export default async function queryMonthIndices() {
-  const endpoint = `${endpoints.elasticsearch}/_aliases`;
+  const endpoint = `${endpoints.pbench_server}/controllers/months`;
 
   return request.get(endpoint);
 }

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -28,11 +28,21 @@ export async function searchQuery(params) {
       },
       data: {
         size: 10000,
-        filter: {
-          range: {
-            '@timestamp': {
-              gte: selectedDateRange.start,
-              lte: selectedDateRange.end,
+        query: {
+          bool: {
+            filter: {
+              range: {
+                '@timestamp': {
+                  gte: selectedDateRange.start,
+                  lte: selectedDateRange.end,
+                },
+              },
+            },
+            must: {
+              query_string: {
+                query: `*${query}*`,
+                analyze_wildcard: true,
+              },
             },
           },
         },
@@ -44,17 +54,7 @@ export async function searchQuery(params) {
             },
           },
         ],
-        query: {
-          filtered: {
-            query: {
-              query_string: {
-                query: `*${query}*`,
-                analyze_wildcard: true,
-              },
-            },
-          },
-        },
-        fields: selectedFields,
+        _source: { include: selectedFields },
       },
     });
   } catch (error) {


### PR DESCRIPTION
Revise dashboard Elasticsearch queries to be compatible with Elasticsearch 7 syntax in order to work with 0.71 Pbench server, which now indexes to Elasticsearch 7.

Of special note: this also switches the dashboard over to use the two Pbench server "native query" APIs I've implemented, replacing both the `query` services and the `fetch` model effect transformations for `queryControllers`/`fetchControllers` and `queryMonthIndices`/`fetchMonthIndices`.

Also, during testing I found inconsistencies in the search behavior that seem to have been pre-existing bugs; e.g., the search state passed on to `fetchIterationSamples` didn't contain the `id` property required by that code to construct the queries. (Pay special attention to these changes.)

The dashboard actually runs on my 0.71 server VM and the RDU2 elasticsearch instance. The `yarn test` passes, with a warning for the `SiderMenu` test which apparently isn't including a `key` prop in a component list: not my change, and I decided not to mess with it. The e2e test script passes locally; hopefully will also on TravisCI.

The new `endpoints.js` should look something like this:

```
window.endpoints = {
  elasticsearch: 'http://elasticsearch.intlab.perf-infra.lab.eng.rdu2.redhat.com',
  results: 'http://dhcp31-170.perf.lab.eng.bos.redhat.com:8901',
  graphql: 'http://graphql.perf.lab.eng.bos.redhat.com:9466',
  prefix: 'drb.',
  result_index: 'v5.result-data-sample.',
  result_data_index: 'v5.result-data.',
  run_index: 'v6.run-data.',
  run_toc_index: 'v6.run-toc.',
  pbench_server: 'http://dhcp31-170.perf.lab.eng.bos.redhat.com:8001/api/v1',
};
```

Note that I changed the placeholders for the index strings to be a bit more useful. Ideally, we'll be able to convert the dashboard over to a server-driven configuration like my [#2024](https://github.com/distributed-system-analysis/pbench/pull/2024) endpoint configuration API, which would remove all of this complexity.

Also of note is my [Server API Architecture](https://docs.google.com/document/d/1c0bauJ9DM7MckFKus8XuTfkqZuLvVONnpnRDoM_TCik/edit#) document, which has before/after payload samples and additional notes.