### PR TITLE
Improved mock generation with mocked network request responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Start Development Server
 $ yarn start
 ```
 
+Start Mock Development Server
+```bash
+$ yarn start:mock
+```
+
 This will automatically open the application on [http://localhost:8000](http://localhost:8000).
 
 ## Local Development
@@ -85,6 +90,8 @@ window.endpoints = {
   run_toc_index: 'v.run-toc.'
 };
 ```
+
+`public/endpoints.mock.js` contains references to the mocked environment. The dashboard will automatically intercept requests made to an external datastore when `pbench_server` is set to `window.origin`. Mocked responses defined in `mock/api.js` will be returned with every intercepted request. 
 
 ## Storage Config
 

--- a/config/config.js
+++ b/config/config.js
@@ -1,6 +1,10 @@
 import pageRoutes from './router.config';
 
 export default {
+  define: {
+    MOCK_UI: process.env.MOCK,
+    ENDPOINTS_ENV: process.env.MOCK ? 'endpoints.mock.js' : 'endpoints.js',
+  },
   dynamicImport: undefined,
   base: '/dashboard/',
   publicPath: process.env.NODE_ENV === 'development' ? '/' : '/dashboard/',

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "precommit": "npm run lint-staged",
     "start": "cross-env UMI_UI=none MOCK=none umi dev",
+    "start:mock": "cross-env UMI_UI=none MOCK=true umi dev",
     "build": "npm --no-git-tag-version version prerelease && umi build",
     "site": "umi-api-doc static && gh-pages -d dist",
     "analyze": "cross-env ANALYZE=true umi build",
@@ -34,6 +35,7 @@
     "@patternfly/react-table": "^2.28.39",
     "ant-design-pro": "^2.1.1",
     "antd": "^3.16.1",
+    "casual": "^1.6.2",
     "classnames": "^2.2.5",
     "dva": "^2.4.1",
     "dva-core": "^1.1.0",

--- a/public/endpoints.mock.js
+++ b/public/endpoints.mock.js
@@ -1,0 +1,11 @@
+window.endpoints = {
+  elasticsearch: 'http://test_domain.com',
+  results: 'http://test_domain.com',
+  graphql: 'http://test_domain.com',
+  pbench_server: window.origin,
+  prefix: 'test_prefix.',
+  result_index: 'v.result-data-sample.',
+  result_data_index: 'v.result-data.',
+  run_index: 'v.run-data.',
+  run_toc_index: 'v.run-toc.',
+};

--- a/src/e2e/controllers.e2e.js
+++ b/src/e2e/controllers.e2e.js
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import { generateMockControllerAggregation, mockIndices } from '../../mock/api';
+import { mockControllers, mockIndices } from '../../mock/api';
 
 let browser;
 let page;
@@ -20,7 +20,7 @@ beforeAll(async () => {
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify(generateMockControllerAggregation),
+        body: JSON.stringify(mockControllers),
       });
     } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({

--- a/src/e2e/results.e2e.js
+++ b/src/e2e/results.e2e.js
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import { generateMockControllerAggregation, mockIndices, mockResults } from '../../mock/api';
+import { mockControllers, mockIndices, mockResults } from '../../mock/api';
 
 let browser;
 let page;
@@ -20,7 +20,7 @@ beforeAll(async () => {
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify(generateMockControllerAggregation),
+        body: JSON.stringify(mockControllers),
       });
     } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({

--- a/src/e2e/session.e2e.js
+++ b/src/e2e/session.e2e.js
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import { generateMockControllerAggregation, mockIndices, mockSession } from '../../mock/api';
+import { mockControllers, mockIndices, mockSession } from '../../mock/api';
 
 let browser;
 let page;
@@ -27,7 +27,7 @@ beforeAll(async () => {
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify(generateMockControllerAggregation),
+        body: JSON.stringify(mockControllers),
       });
     } else if (request.method() === 'GET' && request.url().includes('/controllers/months')) {
       request.respond({

--- a/src/models/search.js
+++ b/src/models/search.js
@@ -22,7 +22,8 @@ export default {
       const { indices } = payload;
       const { endpoints } = window;
 
-      const index = endpoints.prefix + endpoints.run_index + indices[0];
+      // eslint-disable-next-line no-undef
+      const index = MOCK_UI ? 'test_index' : endpoints.prefix + endpoints.run_index + indices[0];
       const mapping = response[index].mappings.properties;
       let fields = [];
       const filters = {};

--- a/src/pages/document.ejs
+++ b/src/pages/document.ejs
@@ -9,7 +9,7 @@
   <link rel="icon" href="<%= context.config.publicPath +'favicon.ico'%>" type="image/x-icon">
   
   <!-- runtime endpoints config -->
-  <script src="<%= context.config.publicPath +'endpoints.js'%>"></script>
+  <script src="<%= context.config.publicPath + context.config.define.ENDPOINTS_ENV%>"></script>
 </head>
 
 <body>

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-underscore-dangle */
@@ -10,7 +11,7 @@ function scrollUntilEmpty(data) {
   const endpoint = `${endpoints.pbench_server}/elasticsearch`;
   const allData = data;
 
-  if (allData.hits.total.value !== allData.hits.hits.length && allData._scroll_id) {
+  if (allData.hits.total.value < allData.hits.hits.length && allData._scroll_id) {
     const indices = `_search/scroll?scroll=1m&scroll_id=${allData._scroll_id}`;
     const scroll = request.post(endpoint, {
       data: { indices },
@@ -19,7 +20,7 @@ function scrollUntilEmpty(data) {
       allData._scroll_id = response._scroll_id;
       allData.hits.total = response.hits.total;
       allData.hits.hits = [...allData.hits.hits, ...response.hits.hits];
-      return scrollUntilEmpty(endpoints, allData);
+      return scrollUntilEmpty(allData);
     });
   }
   return allData;
@@ -53,8 +54,9 @@ export async function queryResults(params) {
       endpoints.run_index,
       selectedDateRange
     )}/_search`;
-
-    const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+    const endpoint = MOCK_UI
+      ? `${endpoints.pbench_server}/datasets/list`
+      : `${endpoints.pbench_server}/elasticsearch`;
 
     return request.post(endpoint, {
       data: {
@@ -104,7 +106,9 @@ export async function queryResult(params) {
     selectedDateRange
   )}/_search`;
 
-  const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/datasets/detail`
+    : `${endpoints.pbench_server}/elasticsearch`;
 
   return request.post(endpoint, {
     data: {
@@ -133,7 +137,9 @@ export async function queryTocResult(params) {
     selectedDateRange
   )}/_search?q=run_data_parent:"${id}"`;
 
-  const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/datasets/toc`
+    : `${endpoints.pbench_server}/elasticsearch`;
 
   return request.post(endpoint, {
     data: {
@@ -154,7 +160,9 @@ export async function queryIterationSamples(params) {
     selectedDateRange
   )}/_search?scroll=1m`;
 
-  const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/datasets/samples`
+    : `${endpoints.pbench_server}/elasticsearch`;
 
   const iterationSampleRequests = [];
   selectedResults.forEach(run => {
@@ -244,7 +252,9 @@ export async function queryTimeseriesData(payload) {
     selectedDateRange
   )}/_search?scroll=1m`;
 
-  const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/datasets/timeseries`
+    : `${endpoints.pbench_server}/elasticsearch`;
 
   const timeseriesRequests = [];
   Object.entries(selectedIterations).forEach(([runId, run]) => {

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import { getAllMonthsWithinRange } from '../utils/moment_constants';
 import request from '../utils/request';
 
@@ -8,7 +9,9 @@ export async function queryIndexMapping(params) {
 
   const mappings = `${endpoints.prefix}${endpoints.run_index}${indices[0]}/_mappings`;
 
-  const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/mappings`
+    : `${endpoints.pbench_server}/elasticsearch`;
 
   return request.post(endpoint, { data: { indices: mappings } });
 }
@@ -23,7 +26,9 @@ export async function searchQuery(params) {
       selectedDateRange
     )}/_search`;
 
-    const endpoint = `${endpoints.pbench_server}/elasticsearch`;
+    const endpoint = MOCK_UI
+      ? `${endpoints.pbench_server}/search`
+      : `${endpoints.pbench_server}/elasticsearch`;
 
     return request.post(endpoint, {
       data: {
@@ -32,35 +37,35 @@ export async function searchQuery(params) {
           ignore_unavailable: true,
         },
         payload: {
-            size: 10000,
-            query: {
-              bool: {
-                filter: {
-                  range: {
-                    '@timestamp': {
-                      gte: selectedDateRange.start,
-                      lte: selectedDateRange.end,
-                    },
+          size: 10000,
+          query: {
+            bool: {
+              filter: {
+                range: {
+                  '@timestamp': {
+                    gte: selectedDateRange.start,
+                    lte: selectedDateRange.end,
                   },
                 },
-                must: {
-                  query_string: {
-                    query: `*${query}*`,
-                    analyze_wildcard: true,
-                  },
+              },
+              must: {
+                query_string: {
+                  query: `*${query}*`,
+                  analyze_wildcard: true,
                 },
               },
             },
-            sort: [
-              {
-                '@timestamp': {
-                  order: 'desc',
-                  unmapped_type: 'boolean',
-                },
-              },
-            ],
-            _source: { include: selectedFields },
           },
+          sort: [
+            {
+              '@timestamp': {
+                order: 'desc',
+                unmapped_type: 'boolean',
+              },
+            },
+          ],
+          _source: { include: selectedFields },
+        },
       },
     });
   } catch (error) {

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,10 +1,13 @@
+/* eslint-disable no-undef */
 import request from '../utils/request';
 
 const { endpoints } = window;
 
 export async function getSession(params) {
   const { sessionId } = params;
-  const endpoint = `${endpoints.pbench_server}/graphql`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/sessions/create`
+    : `${endpoints.pbench_server}/graphql`;
   return request.post(endpoint, {
     data: {
       query: `
@@ -24,7 +27,9 @@ export async function getSession(params) {
 
 // queries all the available shared sessions from the database to display
 export async function getAllSessions() {
-  const endpoint = `${endpoints.pbench_server}/graphql`;
+  const endpoint = MOCK_UI
+    ? `${endpoints.pbench_server}/sessions/list`
+    : `${endpoints.pbench_server}/graphql`;
 
   return request.post(endpoint, {
     data: {

--- a/src/utils/parse.test.js
+++ b/src/utils/parse.test.js
@@ -1,26 +1,20 @@
-import _ from 'lodash';
 import { generateSampleTable, generateClusters } from './parse';
-import { mockDataSample, expectedSampleData, expectedClusterData } from '../../mock/api';
+import { mockSamples } from '../../mock/api';
+
+const parsedSampleTable = generateSampleTable([mockSamples]);
+const parsedClusterData = generateClusters(
+  parsedSampleTable.runs,
+  parsedSampleTable.iterationParams
+);
 
 describe('test generateSampleTable', () => {
-  const parsedSampleTable = generateSampleTable(mockDataSample);
   it('should generate sample table data', () => {
     expect(Object.keys(parsedSampleTable).length > 0);
-  });
-  it('should equal mocked sample table data', () => {
-    expect(_.isEqual(parsedSampleTable, expectedSampleData));
   });
 });
 
 describe('test generateClusters', () => {
-  const parsedClusterData = generateClusters(
-    expectedSampleData.runs,
-    expectedSampleData.iterationParams
-  );
   it('should generate cluster data', () => {
     expect(Object.keys(parsedClusterData).length > 0);
-  });
-  it('should equal mocked cluster data', () => {
-    expect(_.isEqual(parsedClusterData, expectedClusterData));
   });
 });


### PR DESCRIPTION
In order to support continued dashboard component development while the transition to the `pbench_server` is underway, the dashboard requires an advanced mock environment that allows for generation of response data and interception of network requests. By running the the dashboard with `yarn start:mock`, the mock development environment starts and listens for requests to intercept as defined in `mock/api.js`. This PR introduces a "fake data generator" library called casual to mock various response fields.

As server request postprocessing progress continues, the mock responses defined in `mock/api.js` will become significantly smaller. The primary motivation behind mocking requests is to allow for rapid prototyping of React components throughout the dashboard and other various feature development. For more details on the mock development environment, please reference the updated `README.md`. 