### PR TITLE
Remove unused jspdf dependency from node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "enzyme-adapter-react-16": "^1.15.1",
     "html2canvas": "^1.0.0-alpha.12",
     "jschart": "^1.0.7",
-    "jspdf": "^1.5.3",
     "lodash": "^4.17.20",
     "lodash-decorators": "^6.0.0",
     "memoize-one": "^5.0.0",


### PR DESCRIPTION
This PR addresses the following Dependabot alert: https://github.com/distributed-system-analysis/pbench-dashboard/security/dependabot/package.json/jspdf/open