### PR TITLE
Pass logged-in user to controller query

### DIFF
--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -69,10 +69,10 @@ class Controllers extends Component {
   };
 
   fetchControllers = () => {
-    const { dispatch, selectedDateRange } = this.props;
+    const { dispatch, selectedDateRange, username } = this.props;
     dispatch({
       type: 'dashboard/fetchControllers',
-      payload: { selectedDateRange },
+      payload: { selectedDateRange, username },
     });
   };
 

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -28,16 +28,13 @@ function scrollUntilEmpty(data) {
 
 export async function queryControllers(params) {
   try {
-    const { selectedDateRange } = params;
+    const { selectedDateRange, username } = params;
 
     return request.post(`${endpoints.pbench_server}/controllers/list`, {
       data: {
-        user: 'username', // TODO: Will need to get user context here
+        user: username,
         start: selectedDateRange.start,
         end: selectedDateRange.end,
-      },
-      headers: {
-        Authorization: 'Bearer xyzzy', // TODO: real auth token
       },
     });
   } catch (err) {


### PR DESCRIPTION
Pass the logged-in user state through from the controller page to the service and on to the back end.

This appears to work on my server VM, although no controllers will be reported as the datasets are currently all owned by "pbench" and with the dashboard's insistence on valid email addresses there's no way to create a user that the server will see as "pbench". Cie la vie. For the jam session we'll upload datasets owned by actual users.