### PR TITLE
enable onRow click property for react table

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -62,7 +62,7 @@ function fuzzyTextFilterFn(rows, id, filterValue) {
 
 fuzzyTextFilterFn.autoRemove = val => !val;
 
-function Table({ columns, data, isCheckable, onCompare, loadingData }) {
+function Table({ columns, data, isCheckable, onCompare, loadingData, onRowClick }) {
   const filterTypes = React.useMemo(
     () => ({
       fuzzyText: fuzzyTextFilterFn,
@@ -139,7 +139,7 @@ function Table({ columns, data, isCheckable, onCompare, loadingData }) {
                 </div>
               ),
               Cell: ({ row }) => (
-                <div>
+                <div onClick={e => e.stopPropagation()}>
                   <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
                 </div>
               ),
@@ -202,7 +202,11 @@ function Table({ columns, data, isCheckable, onCompare, loadingData }) {
               {page.map(row => {
                 prepareRow(row);
                 return (
-                  <tr className="pf-m-hoverable" {...row.getRowProps()}>
+                  <tr
+                    className="pf-m-hoverable"
+                    {...row.getRowProps()}
+                    onClick={onRowClick ? () => onRowClick(row.original) : null}
+                  >
                     {row.cells.map(cell => {
                       return (
                         <td {...cell.getCellProps()}>

--- a/src/components/Table/index.less
+++ b/src/components/Table/index.less
@@ -1,8 +1,16 @@
 tr > td > span > a {
-  text-decoration: none !important;
   color: inherit !important;
+  text-decoration: none !important;
 }
 
 .table-wrapper {
   overflow-x: auto;
+}
+
+a:hover {
+  font-weight: normal !important;
+}
+
+tr:is(.pf-m-hoverable):hover {
+  background: aliceblue;
 }

--- a/src/components/Table/index.less
+++ b/src/components/Table/index.less
@@ -1,14 +1,5 @@
-tr > td > span > a {
-  color: inherit !important;
-  text-decoration: none !important;
-}
-
 .table-wrapper {
   overflow-x: auto;
-}
-
-a:hover {
-  font-weight: normal !important;
 }
 
 tr:is(.pf-m-hoverable):hover {

--- a/src/e2e/controllers.e2e.js
+++ b/src/e2e/controllers.e2e.js
@@ -43,18 +43,18 @@ afterAll(() => {
 
 describe('controller page component', () => {
   test('should load controllers', async () => {
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(mockControllers[0].controller);
   });
 
   test('should search for controller name', async () => {
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     await page.waitForSelector('div.pf-c-input-group > input');
@@ -62,9 +62,9 @@ describe('controller page component', () => {
     await page.type('div.pf-c-input-group > input', testController);
     await page.waitForSelector('div.pf-c-input-group > button');
     await page.click('div.pf-c-input-group > button');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const filteredController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(filteredController).toBe(testController);
@@ -73,9 +73,9 @@ describe('controller page component', () => {
   test('should reset search results', async () => {
     await page.waitForSelector('div.pf-c-input-group > input');
     await page.click('div.pf-c-input-group > input');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     let testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     for (let i = 0; i < testController.length; i += 1) {
@@ -83,9 +83,9 @@ describe('controller page component', () => {
     }
     await page.waitForSelector('div.pf-c-input-group > button');
     await page.click('div.pf-c-input-group > button');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(mockControllers[0].controller);
@@ -94,9 +94,9 @@ describe('controller page component', () => {
   test('should sort controllers column alphabetically ascending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(1) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(1) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(
@@ -107,9 +107,9 @@ describe('controller page component', () => {
   test('should sort controllers column alphabetically descending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(1) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(1) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(
@@ -122,9 +122,9 @@ describe('controller page component', () => {
   test('should sort last modified column chronologically ascending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(2) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(2) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(
@@ -135,9 +135,9 @@ describe('controller page component', () => {
   test('should sort last modified column chronologically descending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(2) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(2) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(
@@ -150,9 +150,9 @@ describe('controller page component', () => {
   test('should sort results column numerically ascending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(3) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(3) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(
@@ -163,9 +163,9 @@ describe('controller page component', () => {
   test('should sort results column numerically descending', async () => {
     await page.waitForSelector('table > thead > tr > th:nth-child(3) > div:nth-child(1) > span');
     await page.click('table > thead > tr > th:nth-child(3) > div:nth-child(1) > span');
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(

--- a/src/e2e/results.e2e.js
+++ b/src/e2e/results.e2e.js
@@ -50,21 +50,21 @@ afterAll(() => {
 
 describe('results page component', () => {
   test('should load controllers', async () => {
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(mockControllers[0].controller);
   });
 
   test('should navigate to result', async () => {
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
-    await page.click('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.click('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     await page.waitForSelector('section.pf-c-page__main-section.pf-m-light > div > h1');
     const pageHeader = await page.$eval(
       'section.pf-c-page__main-section.pf-m-light > div > h1',

--- a/src/e2e/session.e2e.js
+++ b/src/e2e/session.e2e.js
@@ -50,9 +50,9 @@ afterAll(() => {
 
 describe('session flow', () => {
   test('should load controllers', async () => {
-    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a');
+    await page.waitForSelector('table > tbody > tr:nth-child(1) > td:nth-child(1) > span');
     const testController = await page.$eval(
-      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span > a',
+      'table > tbody > tr:nth-child(1) > td:nth-child(1) > span',
       elem => elem.innerHTML
     );
     expect(testController).toBe(mockControllers[0].controller);

--- a/src/pages/Controllers/index.js
+++ b/src/pages/Controllers/index.js
@@ -151,11 +151,7 @@ class Controllers extends Component {
       {
         Header: 'Controller',
         accessor: 'controller',
-        Cell: row => (
-          <span>
-            <a onClick={() => this.retrieveResults(row.value)}>{row.value}</a>
-          </span>
-        ),
+        Cell: row => <span>{row.value}</span>,
       },
       {
         Header: 'Last Modified',
@@ -175,13 +171,19 @@ class Controllers extends Component {
             <FontAwesomeIcon
               color="gold"
               icon={faStar}
-              onClick={() => this.unfavoriteController(cell.row.original.controller)}
+              onClick={e => {
+                e.stopPropagation();
+                this.unfavoriteController(cell.row.original.controller);
+              }}
             />
           ) : (
             <FontAwesomeIcon
               color="lightgrey"
               icon={faStar}
-              onClick={() => this.favoriteController(cell.row.original.controller)}
+              onClick={e => {
+                e.stopPropagation();
+                this.favoriteController(cell.row.original.controller);
+              }}
             />
           ),
       },
@@ -211,8 +213,9 @@ class Controllers extends Component {
                   style={{ marginTop: 20 }}
                   columns={columns}
                   data={controllers}
-                  onRowClick={record => {
-                    this.retrieveResults(record);
+                  onRowClick={row => {
+                    const { controller } = row;
+                    this.retrieveResults(controller);
                   }}
                   loadingData={loadingControllers}
                 />

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -156,11 +156,7 @@ class Results extends Component {
       {
         Header: 'Result',
         accessor: 'result',
-        Cell: row => (
-          <span>
-            <a onClick={() => this.retrieveResults(row.cell.row)}>{row.value}</a>
-          </span>
-        ),
+        Cell: row => <span>{row.value}</span>,
       },
       {
         Header: 'Config',
@@ -185,13 +181,19 @@ class Results extends Component {
             <FontAwesomeIcon
               color="gold"
               icon={faStar}
-              onClick={() => this.unfavoriteResult(cell.row.original.result)}
+              onClick={e => {
+                e.stopPropagation();
+                this.unfavoriteResult(cell.row.original.result);
+              }}
             />
           ) : (
             <FontAwesomeIcon
               color="lightgrey"
               icon={faStar}
-              onClick={() => this.favoriteResult(cell.row.original.result)}
+              onClick={e => {
+                e.stopPropagation();
+                this.favoriteResult(cell.row.original.result);
+              }}
             />
           ),
       },
@@ -212,8 +214,9 @@ class Results extends Component {
                 onCompare={selectedRowIds => this.compareResults(selectedRowIds)}
                 columns={columns}
                 data={results}
-                onRowClick={record => {
-                  this.retrieveResults(record);
+                onRowClick={row => {
+                  const { result } = row;
+                  this.retrieveResults(result);
                 }}
                 loadingData={loading}
                 isCheckable

--- a/src/pages/Summary/index.js
+++ b/src/pages/Summary/index.js
@@ -145,7 +145,7 @@ class Summary extends React.Component {
         <PageSection variant={PageSectionVariants.light}>
           <TextContent>
             <Text component="h1">{selectedControllers.join(', ')}</Text>
-            <Text component="h1">{selectedResults[0].result}</Text>
+            <Text component="h2">{selectedResults[0]}</Text>
           </TextContent>
         </PageSection>
         <PageSection padding="noPadding" isFilled>


### PR DESCRIPTION
We used to make the record name bold on hover which shifted the table columns to the right by some pixel value. 

What this PR does:
- [x] Highlights the row selection on a hover.
- [x] Enable row click property by a handler function passed as props to Table component.
- [x] Stop default propagation of rowclick for row actions such as selecting checkboxes and favoriting records.