### PR TITLE
Adds feature to include expandable subcomponent to Table component

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -62,7 +62,7 @@ function fuzzyTextFilterFn(rows, id, filterValue) {
 
 fuzzyTextFilterFn.autoRemove = val => !val;
 
-function Table({ columns, data, isCheckable, onCompare, loadingData }) {
+function Table({ columns, data, isCheckable, onCompare, loadingData, renderRowSubComponent }) {
   const filterTypes = React.useMemo(
     () => ({
       fuzzyText: fuzzyTextFilterFn,
@@ -86,7 +86,7 @@ function Table({ columns, data, isCheckable, onCompare, loadingData }) {
     }),
     []
   );
-
+  let totalColums = 0;
   const {
     getTableProps,
     getTableBodyProps,
@@ -128,6 +128,7 @@ function Table({ columns, data, isCheckable, onCompare, loadingData }) {
 
     hooks => {
       hooks.visibleColumns.push(visibleColumns => {
+        totalColums = visibleColumns.length;
         if (isCheckable) {
           return [
             {
@@ -202,26 +203,42 @@ function Table({ columns, data, isCheckable, onCompare, loadingData }) {
               {page.map(row => {
                 prepareRow(row);
                 return (
-                  <tr className="pf-m-hoverable" {...row.getRowProps()}>
-                    {row.cells.map(cell => {
-                      return (
-                        <td {...cell.getCellProps()}>
-                          {cell.isGrouped ? (
-                            <>
-                              <span {...row.getToggleRowExpandedProps()}>
-                                {row.isExpanded ? '↓' : '→'}
-                              </span>{' '}
-                              {cell.render('Cell', { editable: false })} ({row.subRows.length})
-                            </>
-                          ) : cell.isAggregated ? (
-                            cell.render('Aggregated')
-                          ) : cell.isPlaceholder ? null : (
-                            cell.render('Cell', { editable: false })
-                          )}
+                  <React.Fragment>
+                    <tr className="pf-m-hoverable" {...row.getRowProps()}>
+                      {row.cells.map(cell => {
+                        return (
+                          <td {...cell.getCellProps()}>
+                            {cell.isGrouped ? (
+                              <>
+                                <span {...row.getToggleRowExpandedProps()}>
+                                  {row.isExpanded ? '↓' : '→'}
+                                </span>{' '}
+                                {cell.render('Cell', { editable: false })} ({row.subRows.length})
+                              </>
+                            ) : cell.isAggregated ? (
+                              cell.render('Aggregated')
+                            ) : cell.isPlaceholder ? null : (
+                              cell.render('Cell', { editable: false })
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                    {row.isExpanded ? (
+                      <tr>
+                        <td colSpan={totalColums}>
+                          {/*
+                              Inside it, call our renderRowSubComponent function. In reality,
+                              you could pass whatever you want as props to
+                              a component like this, including the entire
+                              table instance. But for this example, we'll just
+                              pass the row
+                            */}
+                          {renderRowSubComponent({ row })}
                         </td>
-                      );
-                    })}
-                  </tr>
+                      </tr>
+                    ) : null}
+                  </React.Fragment>
                 );
               })}
             </tbody>


### PR DESCRIPTION
We need the feature to expand individual row of the table for the overview page component.
example: [link](https://react-table.tanstack.com/docs/examples/sub-components)