### PR TITLE
Fix user registration

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,8 +10,8 @@ export const queryRegisterUser = async params => {
       username,
       password,
       email,
-      firstName,
-      lastName,
+      first_name: firstName,
+      last_name: lastName,
     },
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Found during jam session: the parameters passed to the `POST` for user registration don't match the parameter names expected by the server.