### PR TITLE
Use real /datasets/list and /datasets/detail APIs

### DIFF
--- a/src/models/dashboard.js
+++ b/src/models/dashboard.js
@@ -42,42 +42,7 @@ export default {
       });
     },
     *fetchResults({ payload }, { call, put }) {
-      const response = yield call(queryResults, payload);
-      const runs = [];
-
-      response.hits.hits.forEach(result => {
-        const { _source } = result;
-        const { run } = _source;
-        const { name, controller, id, start, end } = run;
-        const metadata = _source['@metadata'];
-
-        const record = {
-          result: name,
-          controller,
-          start,
-          end,
-          id,
-        };
-
-        if (typeof run.config !== 'undefined') {
-          record.config = run.config;
-        }
-        if (typeof run.prefix !== 'undefined') {
-          record['run.prefix'] = run.prefix;
-        }
-        if (typeof metadata !== 'undefined') {
-          if (typeof metadata.controller_dir !== 'undefined') {
-            record['@metadata.controller_dir'] = metadata.controller_dir;
-          }
-          if (typeof metadata.satellite !== 'undefined') {
-            record['@metadata.satellite'] = metadata.satellite;
-          }
-        }
-        runs.push(record);
-      });
-
-      const results = {};
-      results[payload.controller[0]] = runs;
+      const results = yield call(queryResults, payload);
 
       yield put({
         type: 'getResults',
@@ -85,28 +50,7 @@ export default {
       });
     },
     *fetchResult({ payload }, { call, put }) {
-      const response = yield call(queryResult, payload);
-      const result =
-        // eslint-disable-next-line no-underscore-dangle
-        typeof response.hits.hits[0] !== 'undefined' ? response.hits.hits[0]._source : [];
-      let metadataTag = '';
-      const parsedResult = {};
-
-      if (typeof result['@metadata'] !== 'undefined') {
-        metadataTag = '@metadata';
-      } else {
-        metadataTag = '_metadata';
-      }
-
-      parsedResult.runMetadata = {
-        ...result.run,
-        ...result[metadataTag],
-      };
-
-      parsedResult.hostTools = [];
-      result.host_tools_info.forEach(toolData => {
-        parsedResult.hostTools.push(toolData);
-      });
+      const parsedResult = yield call(queryResult, payload);
 
       yield put({
         type: 'getResult',

--- a/src/pages/Results/index.js
+++ b/src/pages/Results/index.js
@@ -36,13 +36,14 @@ class Results extends Component {
   }
 
   componentDidMount() {
-    const { dispatch, results, selectedDateRange, selectedControllers } = this.props;
+    const { dispatch, username, results, selectedDateRange, selectedControllers } = this.props;
 
     if (results.length === 0) {
       dispatch({
         type: 'dashboard/fetchResults',
         payload: {
           selectedDateRange,
+          username,
           controller: selectedControllers,
         },
       });

--- a/src/pages/Summary/index.js
+++ b/src/pages/Summary/index.js
@@ -64,10 +64,11 @@ const tocColumns = [
   },
 ];
 
-@connect(({ global, dashboard, loading }) => ({
+@connect(({ global, dashboard, loading, auth }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
   result: dashboard.result,
+  username: auth.username,
   tocResult: dashboard.tocResult,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
@@ -89,7 +90,7 @@ class Summary extends React.Component {
   }
 
   componentDidMount() {
-    const { dispatch, selectedDateRange, selectedResults } = this.props;
+    const { dispatch, username, selectedDateRange, selectedResults } = this.props;
 
     dispatch({
       type: 'dashboard/fetchIterationSamples',
@@ -99,14 +100,15 @@ class Summary extends React.Component {
       type: 'dashboard/fetchResult',
       payload: {
         selectedDateRange,
-        result: selectedResults[0].result,
+        username,
+        result: selectedResults[0].values.result,
       },
     });
     dispatch({
       type: 'dashboard/fetchTocResult',
       payload: {
         selectedDateRange,
-        id: selectedResults[0].id,
+        id: selectedResults[0].original.id,
       },
     });
   }

--- a/src/services/dashboard.js
+++ b/src/services/dashboard.js
@@ -44,46 +44,14 @@ export async function queryControllers(params) {
 
 export async function queryResults(params) {
   try {
-    const { selectedDateRange, controller } = params;
+    const { selectedDateRange, username, controller } = params;
 
-    const indices = `${getAllMonthsWithinRange(
-      endpoints,
-      endpoints.run_index,
-      selectedDateRange
-    )}/_search`;
-    const endpoint = MOCK_UI
-      ? `${endpoints.pbench_server}/datasets/list`
-      : `${endpoints.pbench_server}/elasticsearch`;
-
-    return request.post(endpoint, {
+    return request.post(`${endpoints.pbench_server}/datasets/list`, {
       data: {
-        indices,
-        payload: {
-          _source: {
-            includes: [
-              '@metadata.controller_dir',
-              '@metadata.satellite',
-              'run.controller',
-              'run.start',
-              'run.end',
-              'run.name',
-              'run.config',
-              'run.prefix',
-              'run.id',
-            ],
-          },
-          sort: {
-            'run.end': {
-              order: 'desc',
-            },
-          },
-          query: {
-            match: {
-              'run.controller': controller[0],
-            },
-          },
-          size: 5000,
-        },
+        user: username,
+        controller: controller[0],
+        start: selectedDateRange.start,
+        end: selectedDateRange.end,
       },
     });
   } catch (error) {
@@ -92,29 +60,13 @@ export async function queryResults(params) {
 }
 
 export async function queryResult(params) {
-  const { selectedDateRange, result } = params;
-
-  const indices = `${getAllMonthsWithinRange(
-    endpoints,
-    endpoints.run_index,
-    selectedDateRange
-  )}/_search`;
-
-  const endpoint = MOCK_UI
-    ? `${endpoints.pbench_server}/datasets/detail`
-    : `${endpoints.pbench_server}/elasticsearch`;
-
-  return request.post(endpoint, {
+  const { selectedDateRange, username, result } = params;
+  return request.post(`${endpoints.pbench_server}/datasets/detail`, {
     data: {
-      indices,
-      data: {
-        query: {
-          match: {
-            'run.name': result,
-          },
-        },
-        sort: '_index',
-      },
+      user: username,
+      name: result,
+      start: selectedDateRange.start,
+      end: selectedDateRange.end,
     },
   });
 }
@@ -126,7 +78,7 @@ export async function queryTocResult(params) {
     endpoints,
     endpoints.run_toc_index,
     selectedDateRange
-  )}/_search?q=run_data_parent:"${id}"`;
+  )}/_search`;
 
   const endpoint = MOCK_UI
     ? `${endpoints.pbench_server}/datasets/toc`
@@ -135,6 +87,10 @@ export async function queryTocResult(params) {
   return request.post(endpoint, {
     data: {
       indices,
+      params: {
+        q: `run_data_parent:"${id}"`,
+        ignore_unavailable: 'true',
+      },
     },
   });
 }


### PR DESCRIPTION
Switch over the dashboard service and model effects to use the Pbench server /datasets/list and /datasets/detail APIs.

This also fixes an issue in the use of the Elasticsearch pass-through API for TOC.