### PR TITLE
filters table while searching(autocomplete)

### DIFF
--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -24,7 +24,12 @@ export default class SearchBar extends PureComponent {
   }
 
   onChange = value => {
+    const { onSearch } = this.props;
     this.setState({ searchValue: value });
+
+    // filters the Table as
+    // the input component changes
+    onSearch(value);
   };
 
   onEnter = event => {


### PR DESCRIPTION
This PR fixes #157

There may be some instances where `onSearch` is null/undefined, depending on whether we want to activate the autocomplete feature, for those cases, we can provide a custom prop `autocomplete: Boolean` to the Table instantiation and conditionally activate `onSearch` property. To test these cases, we have to fix our mock API or staging server to reproduce Table data. (currently, these are empty arrays in every other page other than controllers, so I could only test on the controllers page)