### PR TITLE
doesn't call onRowClick by default

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -205,7 +205,7 @@ function Table({ columns, data, isCheckable, onCompare, loadingData, onRowClick 
                   <tr
                     className="pf-m-hoverable"
                     {...row.getRowProps()}
-                    onClick={onRowClick && onRowClick(row.original)}
+                    onClick={() => onRowClick && onRowClick(row.original)}
                   >
                     {row.cells.map(cell => {
                       return (


### PR DESCRIPTION
Fixes #173 

Why is this change significant?
- when we just reference the function with it's name, it is called by default on every render, so in our case whenever the controllers page was loading, it took the user to the results page (invalidating all tests for the controllers page)
